### PR TITLE
[ETL-332] create lambda iam role

### DIFF
--- a/config/develop/namespaced/s3-to-glue-lambda.yaml
+++ b/config/develop/namespaced/s3-to-glue-lambda.yaml
@@ -3,8 +3,10 @@ template:
   path: src/lambda_function/template.yaml
   artifact_bucket_name: !stack_output_external recover-dev-cloudformation-bucket::BucketName
   artifact_prefix: 'recover/{{ stack_group_config.namespace }}/lambda'
+dependencies:
+  - develop/s3-to-glue-lambda-role.yaml
 stack_name: '{{ stack_group_config.namespace }}-lambda-S3ToGlue'
 stack_tags: {{ stack_group_config.default_stack_tags }}
 parameters:
   Namespace: {{ stack_group_config.namespace }}
-  S3SourceBucketName: !stack_output_external recover-pilot-data-bucket::BucketName
+  S3ToGlueRoleArn: !stack_output_external s3-to-glue-lambda-role::RoleArn

--- a/config/develop/namespaced/s3-to-glue-lambda.yaml
+++ b/config/develop/namespaced/s3-to-glue-lambda.yaml
@@ -2,7 +2,7 @@ template:
   type: sam
   path: src/lambda_function/template.yaml
   artifact_bucket_name: !stack_output_external recover-dev-cloudformation-bucket::BucketName
-  artifact_prefix: 'recover/{{ stack_group_config.namespace }}/lambda'
+  artifact_prefix: 'recover/{{ stack_group_config.namespace }}/src/lambda'
 dependencies:
   - develop/s3-to-glue-lambda-role.yaml
 stack_name: '{{ stack_group_config.namespace }}-lambda-S3ToGlue'

--- a/config/develop/s3-to-glue-lambda-role.yaml
+++ b/config/develop/s3-to-glue-lambda-role.yaml
@@ -1,0 +1,7 @@
+template:
+  path: s3-to-glue-lambda-role.yaml
+stack_name: s3-to-glue-lambda-role
+parameters:
+  S3SourceBucketName: !stack_output_external recover-pilot-data-bucket::BucketName
+stack_tags:
+  {{ stack_group_config.default_stack_tags }}

--- a/config/prod/s3-to-glue-lambda-role.yaml
+++ b/config/prod/s3-to-glue-lambda-role.yaml
@@ -1,0 +1,9 @@
+template:
+  path: s3-to-glue-lambda-role.yaml
+stack_name: s3-to-glue-lambda-role
+dependencies:
+  - prod/s3-to-glue-lambda-role.yaml
+parameters:
+  S3SourceBucketName: {{ stack_group_config.source_bucket }}
+stack_tags:
+  {{ stack_group_config.default_stack_tags }}

--- a/config/prod/s3-to-glue-lambda-role.yaml
+++ b/config/prod/s3-to-glue-lambda-role.yaml
@@ -1,8 +1,6 @@
 template:
   path: s3-to-glue-lambda-role.yaml
 stack_name: s3-to-glue-lambda-role
-dependencies:
-  - prod/s3-to-glue-lambda-role.yaml
 parameters:
   S3SourceBucketName: {{ stack_group_config.source_bucket }}
 stack_tags:

--- a/config/prod/s3-to-glue-lambda.yaml
+++ b/config/prod/s3-to-glue-lambda.yaml
@@ -2,7 +2,7 @@ template:
   type: sam
   path: src/lambda_function/template.yaml
   artifact_bucket_name: !stack_output_external recover-cloudformation-bucket
-  artifact_prefix: 'recover/{{ stack_group_config.namespace }}/lambda'
+  artifact_prefix: 'recover/src/lambda'
 dependencies:
   - prod/s3-to-glue-lambda-role.yaml
 stack_name: '{{ stack_group_config.namespace }}-lambda-S3ToGlue'

--- a/config/prod/s3-to-glue-lambda.yaml
+++ b/config/prod/s3-to-glue-lambda.yaml
@@ -3,8 +3,10 @@ template:
   path: src/lambda_function/template.yaml
   artifact_bucket_name: !stack_output_external recover-cloudformation-bucket
   artifact_prefix: 'recover/{{ stack_group_config.namespace }}/lambda'
+dependencies:
+  - prod/s3-to-glue-lambda-role.yaml
 stack_name: '{{ stack_group_config.namespace }}-lambda-S3ToGlue'
 stack_tags: {{ stack_group_config.default_stack_tags }}
 parameters:
   Namespace: {{ stack_group_config.namespace }}
-  S3SourceBucketName: {{ stack_group_config.source_bucket }}
+  S3ToGlueRoleArn: !stack_output_external s3-to-glue-lambda-role::RoleArn

--- a/src/lambda_function/README.md
+++ b/src/lambda_function/README.md
@@ -61,9 +61,8 @@ sam local invoke -e events/test-trigger-event.json --env-vars test-env-vars.json
 
 ## Launching Lambda stack in AWS
 
-There are two main pieces to launching the s3 to glue lambda. They are the
-`s3 to glue lambda role` and the `s3 to glue lambda` stacks. Generally, updates will
-typically be made to the s3 to glue lambda stacks.
+There are two main stacks involved in the s3 to glue lambda. They are the
+`s3 to glue lambda role` stack and the `s3 to glue lambda` stack.
 
 ### Sceptre
 
@@ -82,7 +81,7 @@ typically be made to the s3 to glue lambda stacks.
 `src/lambda_function/template.yaml`
 
 5. Run the following command to create the lambda stack in your AWS account. Note this will
-also create the lambda s3 to glue IAM role as well:
+also create the lambda s3 to glue IAM role stack as well:
 
 ```shell script
 sceptre --var namespace='test-namespace' launch develop/namespace/s3-to-glue-lambda.yaml

--- a/src/lambda_function/README.md
+++ b/src/lambda_function/README.md
@@ -69,7 +69,7 @@ There are two main stacks involved in the s3 to glue lambda. They are the
 #### Launching in development
 
 1. Create/update the following s3 to glue lambda role [sceptre](https://github.com/Sceptre/sceptre) config file:
-`config/develop/namespaced/s3-to-glue-lambda-role.yaml`
+`config/develop/s3-to-glue-lambda-role.yaml`
 
 2. Create/update the following s3 to glue lambda role [sceptre](https://github.com/Sceptre/sceptre) template file:
 `templates/s3-to-glue-lambda-role.yaml`

--- a/src/lambda_function/README.md
+++ b/src/lambda_function/README.md
@@ -61,17 +61,28 @@ sam local invoke -e events/test-trigger-event.json --env-vars test-env-vars.json
 
 ## Launching Lambda stack in AWS
 
+There are two main pieces to launching the s3 to glue lambda. They are the
+`s3 to glue lambda role` and the `s3 to glue lambda` stacks. Generally, updates will
+typically be made to the s3 to glue lambda stacks.
+
 ### Sceptre
 
 #### Launching in development
 
-1. Create/update the following [sceptre](https://github.com/Sceptre/sceptre) config file:
+1. Create/update the following s3 to glue lambda role [sceptre](https://github.com/Sceptre/sceptre) config file:
+`config/develop/namespaced/s3-to-glue-lambda-role.yaml`
+
+2. Create/update the following s3 to glue lambda role [sceptre](https://github.com/Sceptre/sceptre) template file:
+`templates/s3-to-glue-lambda-role.yaml`
+
+3. Create/update the following s3 to glue lambda [sceptre](https://github.com/Sceptre/sceptre) config file:
 `config/develop/namespaced/s3-to-glue-lambda.yaml`
 
-2. Create/update the following [sceptre](https://github.com/Sceptre/sceptre) template file:
+4. Create/update the following s3 to glue lambda [sceptre](https://github.com/Sceptre/sceptre) template file:
 `src/lambda_function/template.yaml`
 
-3. Run the following command to create the lambda stack in your AWS account:
+5. Run the following command to create the lambda stack in your AWS account. Note this will
+also create the lambda s3 to glue IAM role as well:
 
 ```shell script
 sceptre --var namespace='test-namespace' launch develop/namespace/s3-to-glue-lambda.yaml

--- a/src/lambda_function/template.yaml
+++ b/src/lambda_function/template.yaml
@@ -7,9 +7,9 @@ Description: >
 
 Parameters:
 
-  S3SourceBucketName:
+  S3ToGlueRoleArn:
     Type: String
-    Description: Name of the S3 bucket where source data are stored.
+    Description: Arn for the S3 to Glue Lambda Role
 
   Namespace:
     Type: String
@@ -22,44 +22,6 @@ Parameters:
     Default: cron(59 23 * * ? *)
 
 Resources:
-  S3ToGlueRole:
-      Type: AWS::IAM::Role
-      Properties:
-        AssumeRolePolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-              - lambda.amazonaws.com
-            Action:
-            - sts:AssumeRole
-        ManagedPolicyArns:
-          - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-        Policies:
-        - PolicyName: StartGlueWorkflow
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-            - Effect: Allow
-              Action:
-              - glue:StartWorkflowRun
-              - glue:PutWorkflowRunProperties
-              Resource:
-              - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:workflow/*
-        - PolicyName: AccessS3BucketInputData
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-            - Effect: Allow
-              Action:
-               - s3:Get*
-               - s3:List*
-              Resource:
-              - !Sub arn:aws:s3:::${S3SourceBucketName}
-              - !Sub arn:aws:s3:::${S3SourceBucketName}/*
-
-
   S3ToGlueFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -67,7 +29,7 @@ Resources:
       CodeUri: ./s3_to_glue
       Handler: app.lambda_handler
       Runtime: python3.9
-      Role: !GetAtt S3ToGlueRole.Arn
+      Role: !Ref S3ToGlueRoleArn
       Timeout: 30
       Environment:
         Variables:

--- a/templates/s3-to-glue-lambda-role.yaml
+++ b/templates/s3-to-glue-lambda-role.yaml
@@ -1,0 +1,60 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Transform: AWS::Serverless-2016-10-31
+
+Description: >
+  An IAM Role for the S3 to JSON lambda
+
+Parameters:
+  S3SourceBucketName:
+    Type: String
+    Description: Name of the S3 bucket where source data are stored.
+
+Resources:
+  S3ToGlueRole:
+      Type: AWS::IAM::Role
+      Properties:
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+              - lambda.amazonaws.com
+            Action:
+            - sts:AssumeRole
+        ManagedPolicyArns:
+          - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        Policies:
+        - PolicyName: StartGlueWorkflow
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+              - glue:StartWorkflowRun
+              - glue:PutWorkflowRunProperties
+              Resource:
+              - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:workflow/*
+        - PolicyName: AccessS3BucketInputData
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+               - s3:Get*
+               - s3:List*
+              Resource:
+              - !Sub arn:aws:s3:::${S3SourceBucketName}
+              - !Sub arn:aws:s3:::${S3SourceBucketName}/*
+
+Outputs:
+  RoleName:
+    Value: !Ref S3ToGlueRole
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-RoleName'
+
+  RoleArn:
+    Value: !GetAtt S3ToGlueRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-RoleArn'


### PR DESCRIPTION
**Purpose:** Here, the lambda IAM role (S3ToGlueRole resource) is moved to its own stack so that it is independent of any other resources we are deploying. This way if we need to delete/redeploy the lambda stack the ARN of the S3ToGlueRole won’t change.

- S3 to Glue Lambda config and template
- S3 to Glue Lambda IAM role config and template