### PR TITLE
[ETL-326] block public access in bucket

### DIFF
--- a/templates/s3-bucket.yaml
+++ b/templates/s3-bucket.yaml
@@ -46,6 +46,11 @@ Resources:
         ServerSideEncryptionConfiguration:
         - ServerSideEncryptionByDefault:
             SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls : true
+        BlockPublicPolicy : true
+        IgnorePublicAcls : true
+        RestrictPublicBuckets : true
 
   BucketPolicy:
     Type: AWS::S3::BucketPolicy


### PR DESCRIPTION
**Purpose:** Add to cloudformation so bucket creation would involve blocking public access to bucket. 
This includes blocking:
- ACLs in general that tries to grant public access to bucket
- bucket and access point policies that tries to grant public and cross-account access to bucket
