### PR TITLE
[ETL-361] Fix lambda function to use env var due to failing test

### DIFF
--- a/config/develop/namespaced/s3-to-glue-lambda.yaml
+++ b/config/develop/namespaced/s3-to-glue-lambda.yaml
@@ -5,8 +5,10 @@ template:
   artifact_prefix: 'recover/{{ stack_group_config.namespace }}/src/lambda'
 dependencies:
   - develop/s3-to-glue-lambda-role.yaml
+  - develop/namespaced/glue-workflow.yaml
 stack_name: '{{ stack_group_config.namespace }}-lambda-S3ToGlue'
 stack_tags: {{ stack_group_config.default_stack_tags }}
 parameters:
-  Namespace: {{ stack_group_config.namespace }}
   S3ToGlueRoleArn: !stack_output_external s3-to-glue-lambda-role::RoleArn
+  S3SourceBucketName: !stack_output_external recover-pilot-data-bucket::BucketName
+  PrimaryWorkflowName: !stack_output_external "{{ stack_group_config.namespace }}-glue-workflow::WorkflowName"

--- a/config/prod/s3-to-glue-lambda.yaml
+++ b/config/prod/s3-to-glue-lambda.yaml
@@ -5,8 +5,10 @@ template:
   artifact_prefix: 'recover/src/lambda'
 dependencies:
   - prod/s3-to-glue-lambda-role.yaml
+  - prod/glue-workflow.yaml
 stack_name: '{{ stack_group_config.namespace }}-lambda-S3ToGlue'
 stack_tags: {{ stack_group_config.default_stack_tags }}
 parameters:
-  Namespace: {{ stack_group_config.namespace }}
   S3ToGlueRoleArn: !stack_output_external s3-to-glue-lambda-role::RoleArn
+  S3SourceBucketName: {{ stack_group_config.source_bucket }}
+  PrimaryWorkflowName: !stack_output_external "{{ stack_group_config.namespace }}-glue-workflow::WorkflowName"

--- a/src/lambda_function/template.yaml
+++ b/src/lambda_function/template.yaml
@@ -11,15 +11,21 @@ Parameters:
     Type: String
     Description: Arn for the S3 to Glue Lambda Role
 
-  Namespace:
-    Type: String
-    Description: Namespace of the stack so that it may be unique
-
   Schedule:
     Description: >
       Schedule to execute the lambda function
     Type: String
     Default: cron(59 23 * * ? *)
+
+  S3SourceBucketName:
+    Type: String
+    Description: Name of the S3 bucket where source data are stored.
+
+  PrimaryWorkflowName:
+    Type: String
+    Description: >
+      Name of the main glue workflow that runs glue jobs from S3 to JSON and JSON to Parquet
+
 
 Resources:
   S3ToGlueFunction:
@@ -33,7 +39,8 @@ Resources:
       Timeout: 30
       Environment:
         Variables:
-          NAMESPACE: !Ref Namespace
+          S3_SOURCE_BUCKET_NAME: !Ref S3SourceBucketName
+          PRIMARY_WORKFLOW_NAME: !Ref PrimaryWorkflowName
       Events:
         DailyTrigger:
           Type: Schedule

--- a/tests/test_s3_to_glue_lambda.py
+++ b/tests/test_s3_to_glue_lambda.py
@@ -76,25 +76,6 @@ def test_trigger_event():
     return test_trigger_event
 
 
-@pytest.fixture
-def test_s3_client():
-    test_s3_client = boto3.resource("s3")
-    return test_s3_client
-
-
-@pytest.fixture
-def test_bucket_list():
-    s3 = boto3.resource("s3")
-    test_bucket_list = [bucket.name for bucket in s3.buckets.all()]
-    return test_bucket_list
-
-
-@pytest.fixture
-def test_glue_client():
-    test_glue_client = boto3.client("glue", region_name = "us-east-1")
-    return test_glue_client
-
-
 def test_query_files_to_submit_success(test_s3_bucket_objects, test_trigger_event):
     test_submit_files = app.query_files_to_submit(
         objects=test_s3_bucket_objects,

--- a/tests/test_s3_to_glue_lambda.py
+++ b/tests/test_s3_to_glue_lambda.py
@@ -91,16 +91,8 @@ def test_bucket_list():
 
 @pytest.fixture
 def test_glue_client():
-    test_glue_client = boto3.client("glue")
+    test_glue_client = boto3.client("glue", region_name = "us-east-1")
     return test_glue_client
-
-
-def test_bucket_exists(test_bucket_list):
-    assert (app.BUCKET_NAME in test_bucket_list) == True
-
-
-def test_glue_workflow_exists(test_glue_client):
-    test_glue_client.get_workflow(Name=app.WORKFLOW_NAME)
 
 
 def test_query_files_to_submit_success(test_s3_bucket_objects, test_trigger_event):
@@ -122,15 +114,6 @@ def test_no_files_to_submit_on_date(test_s3_bucket_objects):
         objects=test_s3_bucket_objects,
         files_to_submit=[],
         trigger_event_date=datetime.datetime.now().date(),
-    )
-    assert test_submit_files == []
-
-
-def test_empty_bucket_contents(test_trigger_event):
-    test_submit_files = app.query_files_to_submit(
-        objects={"Contents": []},
-        files_to_submit=[],
-        trigger_event_date=parser.isoparse(test_trigger_event["time"]).date(),
     )
     assert test_submit_files == []
 


### PR DESCRIPTION
**Purpose:** Originally the `lambda function` code hard coded in the `recover dev bucket` and `glue workflow` names and resulted in the tests having to test that those names exist which caused the tests to fail if you switched to the production account or deleted the workflow/changed the name. 

Now the lambda function is more robust as it takes the workflow and bucket names from the cloudformation templates as environment variables and the lambda stack also requires for the glue workflow to exist as a dependency so the tests can be removed.