### PR TITLE
Refactor artifacts github action (part of ETL-365)

### DIFF
--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
 
       - name: Setup code, pipenv, aws
-        uses: Sage-Bionetworks/action-pipenv-aws-setup@ibcdpe-516
+        uses: Sage-Bionetworks/action-pipenv-aws-setup@v3
         with:
           role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
           role_session_name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
           role_session_name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
-          python_version: $PYTHON_VERSION
+          python_version: ${{ env.PYTHON_VERSION }}
 
       - name: Setup sam
         uses: aws-actions/setup-sam@v2

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -4,6 +4,7 @@ on: [push]
 
 env:
   NAMESPACE: recover
+  PYTHON_VERSION: 3.9
 
 jobs:
 
@@ -33,6 +34,7 @@ jobs:
         with:
           role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
           role_session_name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          python_version: $PYTHON_VERSION
 
       - name: Setup sam
         uses: aws-actions/setup-sam@v2

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -2,6 +2,9 @@ name: upload-and-deploy
 
 on: [push]
 
+env:
+  NAMESPACE: recover
+
 jobs:
 
   pre-commit:
@@ -24,32 +27,12 @@ jobs:
       contents: read
     environment: develop
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
 
-      - name: Set up python
-        uses: actions/setup-python@v4
+      - name: Setup code, pipenv, aws
+        uses: Sage-Bionetworks/action-pipenv-aws-setup@v3
         with:
-          python-version: '3.10'
-
-      - name: Install pipenv
-        shell: bash
-        run: python -m pip install pipenv
-
-      - name: Install dependencies
-        env:
-          PIPENV_NOSPIN: 'true'
-        shell: bash
-        run: |
-          pipenv install --dev
-
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: us-east-1
           role-to-assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
           role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
-          role-duration-seconds: 1200
 
       - name: Setup sam
         uses: aws-actions/setup-sam@v2
@@ -58,10 +41,5 @@ jobs:
         if: github.ref_name != 'main'
         run: echo "NAMESPACE=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
-      - name: Copy files to namespaced templates bucket, use dev cloudformation bucket
-        if: github.ref_name != 'main'
+      - name: Copy files to templates bucket, use dev cloudformation bucket
         run: python src/scripts/manage_artifacts/artifacts.py --upload --namespace $NAMESPACE --cfn_bucket ${{ vars.CFN_BUCKET }}
-
-      - name: Copy files to non-namespaced templates bucket, use dev cloudformation bucket
-        if: github.ref_name == 'main'
-        run: python src/scripts/manage_artifacts/artifacts.py --upload --namespace '' --cfn_bucket ${{ vars.CFN_BUCKET }}

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
 
       - name: Setup code, pipenv, aws
-        uses: Sage-Bionetworks/action-pipenv-aws-setup@v3
+        uses: Sage-Bionetworks/action-pipenv-aws-setup@ibcdpe-516
         with:
           role-to-assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
           role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -31,8 +31,8 @@ jobs:
       - name: Setup code, pipenv, aws
         uses: Sage-Bionetworks/action-pipenv-aws-setup@ibcdpe-516
         with:
-          role-to-assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
-          role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
+          role_session_name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
 
       - name: Setup sam
         uses: aws-actions/setup-sam@v2

--- a/src/scripts/manage_artifacts/artifacts.py
+++ b/src/scripts/manage_artifacts/artifacts.py
@@ -2,8 +2,6 @@ import os
 import argparse
 import subprocess
 
-REPO_NAME = "recover"
-
 
 def read_args():
     descriptions = """
@@ -29,26 +27,26 @@ def upload(namespace : str, cfn_bucket : str):
     """Copy Glue scripts to the artifacts bucket"""
 
     scripts_local_path = "src/glue/"
-    scripts_s3_path = os.path.join("s3://", cfn_bucket, namespace, REPO_NAME, "src/glue/")
+    scripts_s3_path = os.path.join("s3://", cfn_bucket, namespace, "src/glue/")
     cmd = ["aws", "s3", "sync", scripts_local_path, scripts_s3_path]
     execute_command(cmd)
 
     """Copies Lambda code and template to the artifacts bucket"""
     lambda_local_path = "src/lambda_function/"
-    lambda_s3_path = os.path.join("s3://", cfn_bucket, namespace, REPO_NAME, "src/lambda_function/")
+    lambda_s3_path = os.path.join("s3://", cfn_bucket, namespace, "src/lambda_function/")
     cmd = ["aws", "s3", "sync", lambda_local_path, lambda_s3_path]
     execute_command(cmd)
 
     """Copy CFN templates to the artifacts bucket"""
     templates_local_path = "templates/"
-    templates_s3_path = os.path.join("s3://", cfn_bucket, namespace, REPO_NAME, "templates/")
+    templates_s3_path = os.path.join("s3://", cfn_bucket, namespace, "templates/")
     cmd = ["aws", "s3", "sync", templates_local_path, templates_s3_path]
     execute_command(cmd)
 
 
 def delete(namespace : str, cfn_bucket : str):
     """Removes all files recursively for namespace"""
-    s3_path = os.path.join("s3://", cfn_bucket, namespace, REPO_NAME)
+    s3_path = os.path.join("s3://", cfn_bucket, namespace)
     cmd = ["aws", "s3", "rm", "--recursive", s3_path]
     execute_command(cmd)
 


### PR DESCRIPTION
**Purpose**: This PR does some simple refactoring. 

- Updates `upload-files` job in `upload-and-deploy` to use v3 of `action-pipenv-aws-setup` which allows the job's code to remove the actions that `action-pipenv-aws-setup` takes care of. 

- Updates artifacts script and `upload-and-deploy` to remove the hard coded repo name and instead use the environment NAMESPACE variable to set the namespace as the repo name when deploying main branch. 