### PR TITLE
[ETL-365] Launch stacks during push and PR to dev AWS account

### DIFF
--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    environment: develop
     steps:
 
       - name: Setup code, pipenv, aws
@@ -45,6 +46,7 @@ jobs:
 
       - name: Copy files to templates bucket, use dev cloudformation bucket
         run: python src/scripts/manage_artifacts/artifacts.py --upload --namespace $NAMESPACE --cfn_bucket ${{ vars.CFN_BUCKET }}
+
 
   sceptre-deploy-branch:
 
@@ -68,10 +70,9 @@ jobs:
       - name: Create directory for remote sceptre templates
         run: mkdir -p templates/remote/
 
-      - name: Deploy namespaced sceptre stacks to dev
+      - name: Set namespace for non-default branch
         if: github.ref_name != 'main'
-        run: pipenv run sceptre --var "namespace=$GITHUB_REF_NAME" launch develop --yes
+        run: echo "NAMESPACE=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
-      - name: Deploy non-namespaced sceptre stacks to dev
-        if: github.ref_name == 'main'
+      - name: Deploy sceptre stacks to dev
         run: pipenv run sceptre --var "namespace=$NAMESPACE" launch develop --yes

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -2,6 +2,9 @@ name: upload-and-deploy
 
 on: [push]
 
+env:
+  NAMESPACE: ${{ github.event.repository.name }}
+
 jobs:
 
   pre-commit:
@@ -65,3 +68,33 @@ jobs:
       - name: Copy files to non-namespaced templates bucket, use dev cloudformation bucket
         if: github.ref_name == 'main'
         run: python src/scripts/manage_artifacts/artifacts.py --upload --namespace '' --cfn_bucket ${{ vars.CFN_BUCKET }}
+
+
+  sceptre-deploy-branch:
+
+    name: Deploy branch using sceptre
+    runs-on: ubuntu-latest
+    needs: [pre-commit, upload-files]
+    environment: develop
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Setup code, pipenv, aws
+        uses: Sage-Bionetworks/action-pipenv-aws-setup@v3
+        with:
+          role-to-assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
+          role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+
+      - name: Create directory for remote sceptre templates
+        run: mkdir -p templates/remote/
+
+      - name: Deploy namespaced sceptre stacks to dev
+        if: github.ref_name != 'main'
+        run: pipenv run sceptre --var "namespace=$GITHUB_REF_NAME" launch develop --yes
+
+      - name: Deploy non-namespaced sceptre stacks to dev
+        if: github.ref_name == 'main'
+        run: pipenv run sceptre --var "namespace=$NAMESPACE" launch develop --yes

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -2,9 +2,9 @@ name: upload-and-deploy
 
 on: [push]
 
-#env:
-#  NAMESPACE: recover
-#  PYTHON_VERSION: 3.9
+env:
+  NAMESPACE: recover
+  PYTHON_VERSION: 3.9
 
 jobs:
 
@@ -17,42 +17,12 @@ jobs:
       - uses: actions/setup-python@v4
       - uses: pre-commit/action@v3.0.0
 
-  load-config:
-
-    name: Loads config file for use in all jobs
-    runs-on: ubuntu-latest
-    needs: pre-commit
-    env:
-      REPO_ENVIRONMENT: develop
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-      - name: Get config
-        id: get-config
-        shell: python
-        run: |
-          import os
-          import yaml
-
-          print(os.getenv["REPO_ENVIRONMENT"])
-          with open("./config/config.yaml", "r") as stream:
-          try:
-            config = yaml.safe_load(stream)
-          except yaml.YAMLError as exc:
-            print(exc)
-          # setting values of github env vars
-          with open(os.environ['GITHUB_ENV'], 'a') as fh:
-            print('NAMESPACE=config["default_stack_tag"]["project_code"]', file=fh)
-            print('PYTHON_VERSION=config["pipenv_python_version"]', file=fh)
-            print('AWS_CREDENTIALS_IAM_ROLE=config[os.getenv["REPO_ENVIRONMENT"]]["AWS_CREDENTIALS_IAM_ROLE"]', file=fh)
-            print('CFN_BUCKET=config[os.getenv["REPO_ENVIRONMENT"]]["CFN_BUCKET"]', file=fh)
-
 
   upload-files:
 
     name: Upload files to S3 bucket in development
     runs-on: ubuntu-latest
-    needs: [pre-commit, load-config]
+    needs: pre-commit
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write
@@ -62,7 +32,7 @@ jobs:
       - name: Setup code, pipenv, aws
         uses: Sage-Bionetworks/action-pipenv-aws-setup@v3
         with:
-          role_to_assume: ${{ env.AWS_CREDENTIALS_IAM_ROLE }}
+          role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
           role_session_name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
           python_version: ${{ env.PYTHON_VERSION }}
 
@@ -74,34 +44,34 @@ jobs:
         run: echo "NAMESPACE=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
       - name: Copy files to templates bucket, use dev cloudformation bucket
-        run: python src/scripts/manage_artifacts/artifacts.py --upload --namespace $NAMESPACE --cfn_bucket ${{ env.CFN_BUCKET }}
+        run: python src/scripts/manage_artifacts/artifacts.py --upload --namespace $NAMESPACE --cfn_bucket ${{ vars.CFN_BUCKET }}
 
-  # sceptre-deploy-branch:
+  sceptre-deploy-branch:
 
-  #   name: Deploy branch using sceptre
-  #   runs-on: ubuntu-latest
-  #   needs: [pre-commit, upload-files]
-  #   environment: develop
-  #   # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-  #   permissions:
-  #     id-token: write
-  #     contents: read
+    name: Deploy branch using sceptre
+    runs-on: ubuntu-latest
+    needs: [pre-commit, upload-files]
+    environment: develop
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
 
-  #   steps:
-  #     - name: Setup code, pipenv, aws
-  #       uses: Sage-Bionetworks/action-pipenv-aws-setup@v3
-  #       with:
-  #         role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
-  #         role_session_name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
-  #         python_version: ${{ env.PYTHON_VERSION }}
+    steps:
+      - name: Setup code, pipenv, aws
+        uses: Sage-Bionetworks/action-pipenv-aws-setup@v3
+        with:
+          role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
+          role_session_name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          python_version: ${{ env.PYTHON_VERSION }}
 
-  #     - name: Create directory for remote sceptre templates
-  #       run: mkdir -p templates/remote/
+      - name: Create directory for remote sceptre templates
+        run: mkdir -p templates/remote/
 
-  #     - name: Deploy namespaced sceptre stacks to dev
-  #       if: github.ref_name != 'main'
-  #       run: pipenv run sceptre --var "namespace=$GITHUB_REF_NAME" launch develop --yes
+      - name: Deploy namespaced sceptre stacks to dev
+        if: github.ref_name != 'main'
+        run: pipenv run sceptre --var "namespace=$GITHUB_REF_NAME" launch develop --yes
 
-  #     - name: Deploy non-namespaced sceptre stacks to dev
-  #       if: github.ref_name == 'main'
-  #       run: pipenv run sceptre --var "namespace=$NAMESPACE" launch develop --yes
+      - name: Deploy non-namespaced sceptre stacks to dev
+        if: github.ref_name == 'main'
+        run: pipenv run sceptre --var "namespace=$NAMESPACE" launch develop --yes

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -85,8 +85,8 @@ jobs:
       - name: Setup code, pipenv, aws
         uses: Sage-Bionetworks/action-pipenv-aws-setup@v3
         with:
-          role-to-assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
-          role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
+          role_session_name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
 
       - name: Create directory for remote sceptre templates
         run: mkdir -p templates/remote/

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [requires]
-python_version = "3.10"
+python_version = "3.9"
 
 [dev-packages]
 pytest = "*"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,19 +1,12 @@
 project_code: recover
-namespace: "{{ var.namespace | default('recover') }}"
+namespace: {{ var.namespace | default('recover') }}
 region: us-east-1
 synapseAuthSsmParameterName: synapse-recover-auth
 source_bucket: recover-s3-bucket-bucket-1rb2h1xfnxpoi
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
-lambda_python_version: "3.9"
-glue_python_shell_version: "3.9"
-glue_version: "4.0"
-pipenv_python_version: "3.9"
-develop:
-  aws_credentials_iam_role: arn:aws:iam::914833433684:role/sagebase-github-oidc-sage-bion-ProviderRolerecover-VTOKECAKJUBV
-  cfn_bucket: recover-dev-cloudformation
-prod:
-  aws_credentials_iam_role: arn:aws:iam::659375444835:role/sagebase-github-oidc-sage-bion-ProviderRolerecover-1PV98HM269O8I
-  cfn_bucket: recover-cloudformation
+s3_to_json_python_shell_version: "3.9"
+s3_to_json_glue_version: "3.0"
+json_to_parquet_glue_version: "4.0"
 default_stack_tags:
   Department: DNT
   Project: recover

--- a/config/develop/glue-job-JSONToParquet.yaml
+++ b/config/develop/glue-job-JSONToParquet.yaml
@@ -11,6 +11,7 @@ parameters:
   TempS3Bucket: !stack_output_external recover-dev-processed-data-bucket::BucketName
   S3ScriptBucket: !stack_output_external recover-dev-cloudformation-bucket::BucketName
   S3ScriptKey: '{{ stack_group_config.namespace }}/recover/src/glue/jobs/json_to_parquet.py'
+  GlueVersion: "{{ stack_group_config.json_to_parquet_glue_version }}"
 stack_tags:
   {{ stack_group_config.default_stack_tags }}
 sceptre_user_data:

--- a/config/develop/glue-job-S3ToJsonS3.yaml
+++ b/config/develop/glue-job-S3ToJsonS3.yaml
@@ -11,5 +11,7 @@ parameters:
   TempS3Bucket: !stack_output_external recover-dev-intermediate-bucket::BucketName
   S3ScriptBucket: !stack_output_external recover-dev-cloudformation-bucket::BucketName
   S3ScriptKey: '{{ stack_group_config.namespace }}/recover/src/glue/jobs/s3_to_json.py'
+  GluePythonShellVersion: "{{ stack_group_config.s3_to_json_python_shell_version }}"
+  GlueVersion: "{{ stack_group_config.s3_to_json_glue_version }}"
 stack_tags:
   {{ stack_group_config.default_stack_tags }}

--- a/src/lambda_function/README.md
+++ b/src/lambda_function/README.md
@@ -27,7 +27,7 @@ Use the SAM CLI to build and test your lambda locally.
 Build your application with the `sam build` command.
 
 ```bash
-cd src/lambda
+cd src/lambda_function
 sam build
 ```
 
@@ -55,7 +55,7 @@ if you are testing a stack deployed as part of a feature branch.
 To invoke the lambda with the test event:
 
 ```bash
-cd src/lambda
+cd src/lambda_function
 sam local invoke -e events/test-trigger-event.json --env-vars test-env-vars.json
 ```
 
@@ -84,7 +84,7 @@ There are two main stacks involved in the s3 to glue lambda. They are the
 also create the lambda s3 to glue IAM role stack as well:
 
 ```shell script
-sceptre --var namespace='test-namespace' launch develop/namespace/s3-to-glue-lambda.yaml
+sceptre --var namespace='test-namespace' launch develop/namespaced/s3-to-glue-lambda.yaml
 ```
 
 #### Launching in production

--- a/src/lambda_function/template.yaml
+++ b/src/lambda_function/template.yaml
@@ -34,7 +34,7 @@ Resources:
       PackageType: Zip
       CodeUri: ./s3_to_glue
       Handler: app.lambda_handler
-      Runtime: python3.9
+      Runtime: python3.10
       Role: !Ref S3ToGlueRoleArn
       Timeout: 30
       Environment:

--- a/src/lambda_function/template.yaml
+++ b/src/lambda_function/template.yaml
@@ -26,6 +26,11 @@ Parameters:
     Description: >
       Name of the main glue workflow that runs glue jobs from S3 to JSON and JSON to Parquet
 
+  LambdaPythonVersion:
+    Type: String
+    Description: Python version to use for this lambda function
+    Default: "3.9"
+
 
 Resources:
   S3ToGlueFunction:
@@ -34,7 +39,7 @@ Resources:
       PackageType: Zip
       CodeUri: ./s3_to_glue
       Handler: app.lambda_handler
-      Runtime: python3.10
+      Runtime: !Sub "python${LambdaPythonVersion}"
       Role: !Ref S3ToGlueRoleArn
       Timeout: 30
       Environment:

--- a/templates/glue-job-JSONToParquet.j2
+++ b/templates/glue-job-JSONToParquet.j2
@@ -42,6 +42,10 @@ Parameters:
     Type: String
     Description: The name of the S3 bucket where temporary files and logs are written.
 
+  GlueVersion:
+    Type: String
+    Description: The version of glue to use for this job
+
 Resources:
 
   {% set datasets = [] %}
@@ -71,7 +75,7 @@ Resources:
         --glue-table: {{ dataset["table_name"] }}
         # --conf spark.sql.adaptive.enabled
       Description: !Sub "${JobDescription} for data type {{ dataset['type'] }}"
-      GlueVersion: "4.0" # Spark 3.3.0, Python 3.10
+      GlueVersion: !Ref GlueVersion
       MaxRetries: !Ref MaxRetries
       Name: {{ dataset["stackname_prefix"] }}-Job
       NumberOfWorkers: !Ref NumberOfWorkers

--- a/templates/glue-job-S3ToJsonS3.yaml
+++ b/templates/glue-job-S3ToJsonS3.yaml
@@ -42,7 +42,7 @@ Parameters:
   PythonVersion:
     Type: String
     Description: The version of Python to use
-    Default: 3.9
+    Default: "3.10"
 
   TimeoutInMinutes:
     Type: Number
@@ -68,7 +68,7 @@ Resources:
         --enable-continuous-cloudwatch-log: true
         --enable-metrics: true
       Description: !Ref JobDescription
-      GlueVersion: "3.0"
+      GlueVersion: "4.0"
       ExecutionProperty:
         MaxConcurrentRuns: !Ref MaxConcurrentRuns
       MaxCapacity: !Ref MaxCapacity

--- a/templates/glue-job-S3ToJsonS3.yaml
+++ b/templates/glue-job-S3ToJsonS3.yaml
@@ -39,10 +39,13 @@ Parameters:
     Description: How many times to retry the job if it fails (integer).
     Default: 0 # TODO change this to 1 after initial development
 
-  PythonVersion:
+  GluePythonShellVersion:
     Type: String
-    Description: The version of Python to use
-    Default: "3.10"
+    Description: The version of Python to use for the Glue Python Shell job
+
+  GlueVersion:
+    Type: String
+    Description: The version of glue to use for this job
 
   TimeoutInMinutes:
     Type: Number
@@ -60,7 +63,7 @@ Resources:
     Properties:
       Command:
         Name: pythonshell
-        PythonVersion: !Ref PythonVersion
+        PythonVersion: !Ref GluePythonShellVersion
         ScriptLocation: !Sub s3://${S3ScriptBucket}/${S3ScriptKey}
       DefaultArguments:
         --TempDir: !Sub s3://${TempS3Bucket}/tmp
@@ -68,7 +71,7 @@ Resources:
         --enable-continuous-cloudwatch-log: true
         --enable-metrics: true
       Description: !Ref JobDescription
-      GlueVersion: "4.0"
+      GlueVersion: !Ref GlueVersion
       ExecutionProperty:
         MaxConcurrentRuns: !Ref MaxConcurrentRuns
       MaxCapacity: !Ref MaxCapacity


### PR DESCRIPTION
**Purpose:** This PR follows the same logic as BridgeDownstream in that it launches stacks to the "recover" and feature branch namespaces of the recover **develop** account. 

This PR also parameterizes some of the python and glue versions used in the glue job stacks as we have varying python and glue versions to be used in the highest level stack config:`config/config.yaml`. Was unable to dynamically parameterize the lambda python runtime in the sam template to this stack because findings say it's not possible to pass this through to the lambda sam template.

- JSON to Parquet glue job: **Glue version 4.0** which supports **Python 3.10**
- S3 to Parquet glue job: **Python 3.9** (this is their highest available python for the glue python shell jobs) which means it can only use **Glue version 3.0**
- Lambda function for S3 to JSON: **Python 3.9** (this is their highest python version that they support, but 3.10 should be coming along in a couple of months)
- Pipenv python/overall environment: **Python 3.9** otherwise we can't sam build lambda especially when using GH actions

