### PR TITLE
[ETL-384] Add production s3 ingestion bucket

### DIFF
--- a/config/prod/s3-ingestion-bucket.yaml
+++ b/config/prod/s3-ingestion-bucket.yaml
@@ -1,0 +1,32 @@
+# Provision a general S3 bucket or a Synapse External Bucket
+# http://docs.synapse.org/articles/custom_storage_location.html
+
+# For use in RECOVER Synapse project (syn51105296)
+
+####
+# NOTE:
+# This is the second bucket in the ingress pipeline for RECOVER project. We will create a copy of the first bucket (recover_input_shared_bucket).
+# This bucket is to make sure we have a data source that is constant and cannot be edited by externals
+# Only Sage has access to this bucket, and this will be linked to the RECOVER Synapse project (syn51105296).
+# The file list will be replicated in Synapse via STS token
+#(https://help.synapse.org/docs/Compute-Directly-on-Data-in-Synapse-or-S3.2048426057.html#ComputeDirectlyonDatainSynapseorS3-Synapse-ManagedSTSStorageLocations)
+####
+template:
+  type: "http"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.0/templates/S3/synapse-external-bucket.j2"
+stack_name: "recover-ingestion-prod"
+stack_tags:
+  OwnerEmail: 'synapse-service-sysbio-recover-data-storage-01@sagebase.org'
+  # This is the shared account (credentials shared on Last Pass) for RECOVER
+  CostCenter: "MGH RECOVER / 122500"
+parameters:
+  # (Optional) true for read-write bucket, false (default) for read-only bucket
+  AllowWriteBucket: 'true'
+  # (Optional) Allow accounts, groups, and users to access bucket (default is no access).
+  GrantAccess:
+    - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
+    - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/meghasyam@sagebase.org'
+    - 'arn:aws:iam::621233246578:role/EES3-RK-6A32F45B-RECOVER' # QA ARN role for Care Evolution
+sceptre_user_data:
+  SynapseIDs:
+    - "3357179" # Megha's synapse profileID

--- a/config/prod/s3-ingestion.yaml
+++ b/config/prod/s3-ingestion.yaml
@@ -8,6 +8,8 @@ stack_tags:
   # This is the shared account (credentials shared on Last Pass) for RECOVER
   CostCenter: "MGH RECOVER / 122500"
 parameters:
+  # (Optional) Name of the created bucket.
+  BucketName: "recover-ingestion-prod"
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).

--- a/config/prod/s3-ingestion.yaml
+++ b/config/prod/s3-ingestion.yaml
@@ -16,6 +16,3 @@ parameters:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
     - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/meghasyam@sagebase.org'
     - 'arn:aws:iam::621233246578:role/EES3-RK-6A32F45B-RECOVER' # QA ARN role for Care Evolution
-sceptre_user_data:
-  SynapseIDs:
-    - "3357179" # Megha's synapse profileID

--- a/config/prod/s3-ingestion.yaml
+++ b/config/prod/s3-ingestion.yaml
@@ -1,16 +1,5 @@
-# Provision a general S3 bucket or a Synapse External Bucket
-# http://docs.synapse.org/articles/custom_storage_location.html
-
-# For use in RECOVER Synapse project (syn51105296)
-
-####
 # NOTE:
-# This is the second bucket in the ingress pipeline for RECOVER project. We will create a copy of the first bucket (recover_input_shared_bucket).
-# This bucket is to make sure we have a data source that is constant and cannot be edited by externals
-# Only Sage has access to this bucket, and this will be linked to the RECOVER Synapse project (syn51105296).
-# The file list will be replicated in Synapse via STS token
-#(https://help.synapse.org/docs/Compute-Directly-on-Data-in-Synapse-or-S3.2048426057.html#ComputeDirectlyonDatainSynapseorS3-Synapse-ManagedSTSStorageLocations)
-####
+# This is the first bucket in the ingress pipeline for RECOVER project.
 template:
   type: "http"
   url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.0/templates/S3/synapse-external-bucket.j2"

--- a/config/prod/s3-ingestion.yaml
+++ b/config/prod/s3-ingestion.yaml
@@ -5,7 +5,6 @@ template:
   url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.0/templates/S3/synapse-external-bucket.j2"
 stack_name: "recover-ingestion-prod"
 stack_tags:
-  OwnerEmail: 'synapse-service-sysbio-recover-data-storage-01@sagebase.org'
   # This is the shared account (credentials shared on Last Pass) for RECOVER
   CostCenter: "MGH RECOVER / 122500"
 parameters:

--- a/config/prod/s3-ingestion.yaml
+++ b/config/prod/s3-ingestion.yaml
@@ -3,13 +3,13 @@
 template:
   type: "http"
   url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.0/templates/S3/synapse-external-bucket.j2"
-stack_name: "recover-ingestion-prod"
+stack_name: "recover-ingestion-bucket"
 stack_tags:
   # This is the shared account (credentials shared on Last Pass) for RECOVER
   CostCenter: "MGH RECOVER / 122500"
 parameters:
   # (Optional) Name of the created bucket.
-  BucketName: "recover-ingestion-prod"
+  BucketName: "recover-ingestion"
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).


### PR DESCRIPTION
Purpose: This creates the ingestion bucket for production data. (SYNAPSE_INPUT_SHARED_BUCKET)

This is the first bucket in the ingress pipeline for RECOVER project. We expect to receive data from Care Evolution in this bucket. This would be the raw version of the data, no QC, no QA - just all the data dump from Care Evolution. Both Care Evolution and Sage have access to this bucket

