### PR TITLE
[ETL-398] Add glue, python version params to relevant prod glue configs

### DIFF
--- a/config/prod/glue-job-JSONToParquet.yaml
+++ b/config/prod/glue-job-JSONToParquet.yaml
@@ -11,6 +11,7 @@ parameters:
   TempS3Bucket: !stack_output_external recover-processed-data-bucket::BucketName
   S3ScriptBucket: !stack_output_external recover-cloudformation-bucket::BucketName
   S3ScriptKey: recover/src/glue/jobs/json_to_parquet.py
+  GlueVersion: "{{ stack_group_config.json_to_parquet_glue_version }}"
 stack_tags:
   {{ stack_group_config.default_stack_tags }}
 sceptre_user_data:

--- a/config/prod/glue-job-S3ToJsonS3.yaml
+++ b/config/prod/glue-job-S3ToJsonS3.yaml
@@ -11,5 +11,7 @@ parameters:
   TempS3Bucket: !stack_output_external recover-intermediate-bucket::BucketName
   S3ScriptBucket: !stack_output_external recover-cloudformation-bucket::BucketName
   S3ScriptKey: recover/src/glue/jobs/s3_to_json.py
+  GluePythonShellVersion: "{{ stack_group_config.s3_to_json_python_shell_version }}"
+  GlueVersion: "{{ stack_group_config.s3_to_json_glue_version }}"
 stack_tags:
   {{ stack_group_config.default_stack_tags }}


### PR DESCRIPTION
**Purpose**: Prod glue job stack configs need to be updated to use the new glue and python version parameters that dev glue job stack configs use.

This also **blocks** a lot of tickets that involve testing stack deployment in prod because currently the glue job stacks error out without this update