### PR TITLE
[ETL-395] Modify prod stack configs to use new pre-ETL bucket name 

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2,7 +2,6 @@ project_code: recover
 namespace: {{ var.namespace | default('recover') }}
 region: us-east-1
 synapseAuthSsmParameterName: synapse-recover-auth
-source_bucket: recover-s3-bucket-bucket-1rb2h1xfnxpoi
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
 s3_to_json_python_shell_version: "3.9"
 s3_to_json_glue_version: "3.0"

--- a/config/prod/config.yaml
+++ b/config/prod/config.yaml
@@ -1,0 +1,5 @@
+ingestion_bucket_name: recover-ingestion
+input_bucket_name: recover-input-data
+cloudformation_artifact_bucket_name: recover-cloudformation
+intermediate_bucket_name: recover-intermediate-data
+processed_data_bucket_name: recover-processed-data

--- a/config/prod/glue-job-role.yaml
+++ b/config/prod/glue-job-role.yaml
@@ -2,7 +2,7 @@ template:
   path: glue-job-role.yaml
 stack_name: glue-job-role
 parameters:
-  S3SourceBucketName: {{ stack_group_config.source_bucket }}
+  S3SourceBucketName: {{ stack_group_config.input_bucket_name }}
   S3IntermediateBucketName: !stack_output_external recover-intermediate-bucket::BucketName
   S3ParquetBucketName: !stack_output_external recover-processed-data-bucket::BucketName
   S3ArtifactBucketName: !stack_output_external recover-cloudformation-bucket::BucketName

--- a/config/prod/s3-to-glue-lambda-role.yaml
+++ b/config/prod/s3-to-glue-lambda-role.yaml
@@ -2,6 +2,6 @@ template:
   path: s3-to-glue-lambda-role.yaml
 stack_name: s3-to-glue-lambda-role
 parameters:
-  S3SourceBucketName: {{ stack_group_config.source_bucket }}
+  S3SourceBucketName: {{ stack_group_config.input_bucket_name }}
 stack_tags:
   {{ stack_group_config.default_stack_tags }}

--- a/config/prod/s3-to-glue-lambda.yaml
+++ b/config/prod/s3-to-glue-lambda.yaml
@@ -2,7 +2,7 @@ template:
   type: sam
   path: src/lambda_function/template.yaml
   artifact_bucket_name: !stack_output_external recover-cloudformation-bucket::BucketName
-  artifact_prefix: '{{ stack_group_config.namespace }}/src/lambda'
+  artifact_prefix: 'recover/src/lambda'
 dependencies:
   - prod/s3-to-glue-lambda-role.yaml
   - prod/glue-workflow.yaml

--- a/config/prod/s3-to-glue-lambda.yaml
+++ b/config/prod/s3-to-glue-lambda.yaml
@@ -1,8 +1,8 @@
 template:
   type: sam
   path: src/lambda_function/template.yaml
-  artifact_bucket_name: !stack_output_external recover-cloudformation-bucket
-  artifact_prefix: 'recover/src/lambda'
+  artifact_bucket_name: !stack_output_external recover-cloudformation-bucket::BucketName
+  artifact_prefix: '{{ stack_group_config.namespace }}/src/lambda'
 dependencies:
   - prod/s3-to-glue-lambda-role.yaml
   - prod/glue-workflow.yaml
@@ -10,5 +10,5 @@ stack_name: '{{ stack_group_config.namespace }}-lambda-S3ToGlue'
 stack_tags: {{ stack_group_config.default_stack_tags }}
 parameters:
   S3ToGlueRoleArn: !stack_output_external s3-to-glue-lambda-role::RoleArn
-  S3SourceBucketName: {{ stack_group_config.source_bucket }}
+  S3SourceBucketName: {{ stack_group_config.input_bucket_name }}
   PrimaryWorkflowName: !stack_output_external "{{ stack_group_config.namespace }}-glue-workflow::WorkflowName"


### PR DESCRIPTION
**Purpose:** We recently created the new pre-ETL (input data) in the prod account, and now the prod stack configs need to be adjusted to use the new bucket. Here a stack group config was also created to house the prod specific bucket names for ease of use across all the prod stacks.