### PR TITLE
[ETL-386] Rename pilot data bucket and link to Synapse

### DIFF
--- a/config/develop/glue-job-role.yaml
+++ b/config/develop/glue-job-role.yaml
@@ -2,7 +2,7 @@ template:
   path: glue-job-role.yaml
 stack_name: glue-job-role
 parameters:
-  S3SourceBucketName: !stack_output_external recover-pilot-data-bucket::BucketName
+  S3SourceBucketName: !stack_output_external recover-dev-input-bucket::BucketName
   S3IntermediateBucketName: !stack_output_external recover-dev-intermediate-bucket::BucketName
   S3ParquetBucketName: !stack_output_external recover-dev-processed-data-bucket::BucketName
   S3ArtifactBucketName: !stack_output_external recover-dev-cloudformation-bucket::BucketName

--- a/config/develop/namespaced/s3-to-glue-lambda.yaml
+++ b/config/develop/namespaced/s3-to-glue-lambda.yaml
@@ -10,5 +10,5 @@ stack_name: '{{ stack_group_config.namespace }}-lambda-S3ToGlue'
 stack_tags: {{ stack_group_config.default_stack_tags }}
 parameters:
   S3ToGlueRoleArn: !stack_output_external s3-to-glue-lambda-role::RoleArn
-  S3SourceBucketName: !stack_output_external recover-pilot-data-bucket::BucketName
+  S3SourceBucketName: !stack_output_external recover-dev-input-bucket::BucketName
   PrimaryWorkflowName: !stack_output_external "{{ stack_group_config.namespace }}-glue-workflow::WorkflowName"

--- a/config/develop/s3-input-bucket.yaml
+++ b/config/develop/s3-input-bucket.yaml
@@ -1,0 +1,10 @@
+template:
+  type: file
+  path: s3-bucket.yaml
+stack_name: recover-dev-input-bucket
+dependencies:
+  - develop/cfn-s3objects-macro.yaml
+parameters:
+  BucketName: recover-dev-input-data
+  SynapseIds: "3461799,3357179" # RecoverETL and meghasyam
+  Namespace: {{ stack_group_config.namespace }}

--- a/config/develop/s3-pilot-data.yaml
+++ b/config/develop/s3-pilot-data.yaml
@@ -1,6 +1,0 @@
-template:
-  type: file
-  path: s3-bucket.yaml
-stack_name: recover-pilot-data-bucket
-parameters:
-  BucketName: recover-pilot-data

--- a/config/develop/s3-to-glue-lambda-role.yaml
+++ b/config/develop/s3-to-glue-lambda-role.yaml
@@ -2,6 +2,6 @@ template:
   path: s3-to-glue-lambda-role.yaml
 stack_name: s3-to-glue-lambda-role
 parameters:
-  S3SourceBucketName: !stack_output_external recover-pilot-data-bucket::BucketName
+  S3SourceBucketName: !stack_output_external recover-dev-input-bucket::BucketName
 stack_tags:
   {{ stack_group_config.default_stack_tags }}

--- a/templates/s3-bucket.yaml
+++ b/templates/s3-bucket.yaml
@@ -14,7 +14,7 @@ Parameters:
     Default: ''
 
   SynapseIds:
-    Type: List<String>
+    Type: CommaDelimitedList
     Default: ''
     Description: Synapse ids to set as owners of this bucket
     ConstraintDescription: >-
@@ -79,7 +79,6 @@ Resources:
               Action:
                 - 's3:ListBucket*'
                 - 's3:GetBucketLocation'
-
               Resource: !Sub ${Bucket.Arn}
             - !Ref AWS::NoValue
           - !If


### PR DESCRIPTION
* Pilot bucket stack renamed to recover-dev-input-bucket and bucket renamed to recover-dev-input-data
* Synapse permissions granted through use of `SynapseIds` parameter.