### PR TITLE
[ETL-382] Update folder structure of dev resources

### DIFF
--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -3,7 +3,7 @@ name: upload-and-deploy
 on: [push]
 
 env:
-  NAMESPACE: recover
+  NAMESPACE: main
   PYTHON_VERSION: 3.9
 
 jobs:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,5 +1,5 @@
 project_code: recover
-namespace: {{ var.namespace | default('recover') }}
+namespace: {{ var.namespace | default('main') }}
 region: us-east-1
 synapseAuthSsmParameterName: synapse-recover-auth
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9

--- a/config/develop/glue-job-JSONToParquet.yaml
+++ b/config/develop/glue-job-JSONToParquet.yaml
@@ -10,7 +10,7 @@ parameters:
   JobRole: !stack_output_external glue-job-role::RoleArn
   TempS3Bucket: !stack_output_external recover-dev-processed-data-bucket::BucketName
   S3ScriptBucket: !stack_output_external recover-dev-cloudformation-bucket::BucketName
-  S3ScriptKey: '{{ stack_group_config.namespace }}/recover/src/glue/jobs/json_to_parquet.py'
+  S3ScriptKey: '{{ stack_group_config.namespace }}/src/glue/jobs/json_to_parquet.py'
   GlueVersion: "{{ stack_group_config.json_to_parquet_glue_version }}"
 stack_tags:
   {{ stack_group_config.default_stack_tags }}

--- a/config/develop/glue-job-S3ToJsonS3.yaml
+++ b/config/develop/glue-job-S3ToJsonS3.yaml
@@ -10,7 +10,7 @@ parameters:
   JobRole: !stack_output_external glue-job-role::RoleArn
   TempS3Bucket: !stack_output_external recover-dev-intermediate-bucket::BucketName
   S3ScriptBucket: !stack_output_external recover-dev-cloudformation-bucket::BucketName
-  S3ScriptKey: '{{ stack_group_config.namespace }}/recover/src/glue/jobs/s3_to_json.py'
+  S3ScriptKey: '{{ stack_group_config.namespace }}/src/glue/jobs/s3_to_json.py'
   GluePythonShellVersion: "{{ stack_group_config.s3_to_json_python_shell_version }}"
   GlueVersion: "{{ stack_group_config.s3_to_json_glue_version }}"
 stack_tags:

--- a/config/develop/namespaced/s3-to-glue-lambda.yaml
+++ b/config/develop/namespaced/s3-to-glue-lambda.yaml
@@ -2,7 +2,7 @@ template:
   type: sam
   path: src/lambda_function/template.yaml
   artifact_bucket_name: !stack_output_external recover-dev-cloudformation-bucket::BucketName
-  artifact_prefix: '{{ stack_group_config.namespace }}/recover/src/lambda'
+  artifact_prefix: '{{ stack_group_config.namespace }}/src/lambda'
 dependencies:
   - develop/s3-to-glue-lambda-role.yaml
   - develop/namespaced/glue-workflow.yaml

--- a/templates/glue-tables.j2
+++ b/templates/glue-tables.j2
@@ -8,7 +8,6 @@ Parameters:
     Description: >-
       The namespace string used to build up the path to the correct object keys
       in the bucket
-    Default: recover
 
   S3IntermediateBucketName:
     Type: String

--- a/templates/glue-workflow.j2
+++ b/templates/glue-workflow.j2
@@ -7,7 +7,6 @@ Parameters:
   Namespace:
     Type: String
     Description: The namespace to which we write the datasets.
-    Default: recover
 
   JsonBucketName:
     Type: String


### PR DESCRIPTION
**Purpose:** This PR corrects the filepaths that various configs point to for their scripts so it follows this pattern now:
`<namespace>/src/...`. Our default namespace will be `main` when deploying to main branch as well as in production and CI/CD has been updated to reflect that. 