### PR TITLE
[ETL-386] Grant Synapse access to dev pre-ETL bucket

### DIFF
--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -75,4 +75,4 @@ jobs:
         run: echo "NAMESPACE=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
       - name: Deploy sceptre stacks to dev
-        run: pipenv run sceptre --var "namespace=$NAMESPACE" launch develop --yes
+        run: pipenv run sceptre --var "namespace=${{ env.NAMESPACE }}" launch develop --yes

--- a/config/develop/namespaced/s3-input-bucket-owner-txt.yaml
+++ b/config/develop/namespaced/s3-input-bucket-owner-txt.yaml
@@ -1,0 +1,11 @@
+template:
+  type: file
+  path: s3-owner-txt.yaml
+stack_name: "{{ stack_group_config.namespace }}-recover-dev-input-bucket-owner-txt"
+dependencies:
+  - develop/cfn-s3objects-macro.yaml
+  - develop/s3-input-bucket.yaml
+parameters:
+  BucketName: !stack_output_external recover-dev-input-bucket::BucketName
+  SynapseIds: "3461799,3357179" # RecoverETL and meghasyam
+  OwnerTxtKeyPrefix: {{ stack_group_config.namespace }}

--- a/config/develop/s3-input-bucket.yaml
+++ b/config/develop/s3-input-bucket.yaml
@@ -2,9 +2,6 @@ template:
   type: file
   path: s3-bucket.yaml
 stack_name: recover-dev-input-bucket
-dependencies:
-  - develop/cfn-s3objects-macro.yaml
 parameters:
   BucketName: {{ stack_group_config.input_bucket_name }}
-  SynapseIds: "3461799,3357179" # RecoverETL and meghasyam
-  OwnerTxtKeyPrefix: {{ stack_group_config.namespace }}
+  ConnectToSynapse: "true"

--- a/config/develop/s3-input-bucket.yaml
+++ b/config/develop/s3-input-bucket.yaml
@@ -7,4 +7,4 @@ dependencies:
 parameters:
   BucketName: {{ stack_group_config.input_bucket_name }}
   SynapseIds: "3461799,3357179" # RecoverETL and meghasyam
-  Namespace: {{ stack_group_config.namespace }}
+  OwnerTxtKeyPrefix: {{ stack_group_config.namespace }}

--- a/config/prod/namespaced/s3-input-bucket-owner-txt.yaml
+++ b/config/prod/namespaced/s3-input-bucket-owner-txt.yaml
@@ -1,0 +1,11 @@
+template:
+  type: file
+  path: s3-owner-txt.yaml
+stack_name: "{{ stack_group_config.namespace }}-recover-input-bucket-owner-txt"
+dependencies:
+  - prod/cfn-s3objects-macro.yaml
+  - prod/s3-input-bucket.yaml
+parameters:
+  BucketName: !stack_output_external recover-input-bucket::BucketName
+  SynapseIds: "3461799,3357179" # RecoverETL and meghasyam
+  OwnerTxtKeyPrefix: {{ stack_group_config.namespace }}

--- a/config/prod/s3-input-bucket.yaml
+++ b/config/prod/s3-input-bucket.yaml
@@ -8,6 +8,6 @@ dependencies:
 parameters:
   BucketName: {{ stack_group_config.input_bucket_name }}
   SynapseIds: "3461799"
-  Namespace: {{ stack_group_config.namespace }}
+  OwnerTxtKeyPrefix: {{ stack_group_config.namespace }}
 stack_tags:
   {{ stack_group_config.default_stack_tags }}

--- a/config/prod/s3-input-bucket.yaml
+++ b/config/prod/s3-input-bucket.yaml
@@ -3,11 +3,7 @@ template:
   type: file
   path: s3-bucket.yaml
 stack_name: recover-input-bucket
-dependencies:
-  - prod/cfn-s3objects-macro.yaml
 parameters:
   BucketName: {{ stack_group_config.input_bucket_name }}
-  SynapseIds: "3461799"
-  OwnerTxtKeyPrefix: {{ stack_group_config.namespace }}
 stack_tags:
   {{ stack_group_config.default_stack_tags }}

--- a/config/prod/s3-processed-data-bucket-owner-txt.yaml
+++ b/config/prod/s3-processed-data-bucket-owner-txt.yaml
@@ -1,0 +1,11 @@
+template:
+  type: file
+  path: s3-owner-txt.yaml
+stack_name: "{{ stack_group_config.namespace }}-recover-processed-data-bucket-owner-txt"
+dependencies:
+  - prod/cfn-s3objects-macro.yaml
+  - prod/s3-processed-data-bucket.yaml
+parameters:
+  BucketName: !stack_output_external recover-processed-data-bucket::BucketName
+  SynapseIds: "3461799" # recoverETL
+  OwnerTxtKeyPrefix: "{{ stack_group_config.namespace }}/parquet"

--- a/config/prod/s3-processed-data-bucket.yaml
+++ b/config/prod/s3-processed-data-bucket.yaml
@@ -7,6 +7,6 @@ dependencies:
 parameters:
   BucketName: {{ stack_group_config.processed_data_bucket_name }}
   SynapseIds: "3461799"
-  Namespace: {{ stack_group_config.namespace }}
+  OwnerTxtKeyPrefix: "{{ stack_group_config.namespace }}/parquet"
 stack_tags:
   {{ stack_group_config.default_stack_tags }}

--- a/config/prod/s3-processed-data-bucket.yaml
+++ b/config/prod/s3-processed-data-bucket.yaml
@@ -2,11 +2,8 @@ template:
   type: file
   path: s3-bucket.yaml
 stack_name: recover-processed-data-bucket
-dependencies:
-  - prod/cfn-s3objects-macro.yaml
 parameters:
   BucketName: {{ stack_group_config.processed_data_bucket_name }}
-  SynapseIds: "3461799"
-  OwnerTxtKeyPrefix: "{{ stack_group_config.namespace }}/parquet"
+  ConnectToSynapse: "true"
 stack_tags:
   {{ stack_group_config.default_stack_tags }}

--- a/templates/s3-bucket.yaml
+++ b/templates/s3-bucket.yaml
@@ -1,7 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
 
-Transform: S3Objects
-
 Description: >-
   This S3 bucket will be used for development and production,
   and for storing partly or fully processed data
@@ -13,24 +11,18 @@ Parameters:
     Description: Name of the bucket.
     Default: ''
 
-  SynapseIds:
-    Type: CommaDelimitedList
-    Default: ''
-    Description: Synapse ids to set as owners of this bucket
-    ConstraintDescription: >-
-      List of Synapse users or team IDs separated by commas
-      (i.e. 1111111, 2222222)
-
-  OwnerTxtKeyPrefix:
+  ConnectToSynapse:
     Type: String
-    Default: ""
-    Description: >-
-      The key prefix to write owner.txt.
+    Description: Whether to grant Synapse read/write permissions on the bucket.
+    AllowedValues:
+      - "true"
+      - "false"
+    Default: "false"
 
 Conditions:
   HasBucketName: !Not [!Equals [!Ref BucketName, ""]]
   ConnectToSynapse:
-    !Not [!Equals [!Join [",", !Ref SynapseIds], ""]]
+    !Equals [!Ref ConnectToSynapse, "true"]
 
 Resources:
   Bucket:
@@ -91,21 +83,6 @@ Resources:
                 - 's3:*MultipartUpload*'
               Resource: !Sub ${Bucket.Arn}/*
             - !Ref AWS::NoValue
-
-  SynapseOwnerFile:
-    Type: AWS::S3::Object
-    Condition: ConnectToSynapse
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-            - E3001
-    Properties:
-      Target:
-        Bucket: !Ref Bucket
-        Key: !Sub ${OwnerTxtKeyPrefix}/owner.txt
-        ContentType: text
-      Body: !Join [ ",", !Ref SynapseIds ]
 
 Outputs:
 

--- a/templates/s3-bucket.yaml
+++ b/templates/s3-bucket.yaml
@@ -21,12 +21,11 @@ Parameters:
       List of Synapse users or team IDs separated by commas
       (i.e. 1111111, 2222222)
 
-  Namespace:
+  OwnerTxtKeyPrefix:
     Type: String
     Default: ""
     Description: >-
-      The namespace string used to build up the path to the correct object keys
-      in the bucket
+      The key prefix to write owner.txt.
 
 Conditions:
   HasBucketName: !Not [!Equals [!Ref BucketName, ""]]
@@ -104,7 +103,7 @@ Resources:
     Properties:
       Target:
         Bucket: !Ref Bucket
-        Key: !Sub ${Namespace}/parquet/owner.txt
+        Key: !Sub ${OwnerTxtKeyPrefix}/owner.txt
         ContentType: text
       Body: !Join [ ",", !Ref SynapseIds ]
 

--- a/templates/s3-owner-txt.yaml
+++ b/templates/s3-owner-txt.yaml
@@ -1,0 +1,41 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Transform: S3Objects
+
+Description: >-
+  Stores an owner.txt to an S3 key.
+
+Parameters:
+
+  BucketName:
+    Type: String
+    Description: Name of the bucket.
+
+  SynapseIds:
+    Type: CommaDelimitedList
+    Description: Synapse ids to set as owners of this bucket
+    ConstraintDescription: >-
+      List of Synapse users or team IDs separated by commas
+      (i.e. 1111111, 2222222)
+
+  OwnerTxtKeyPrefix:
+    Type: String
+    Default: ""
+    Description: >-
+      The key prefix to write owner.txt. It will be written
+      to the root of the bucket if no value is provided.
+
+Resources:
+  SynapseOwnerFile:
+    Type: AWS::S3::Object
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3001
+    Properties:
+      Target:
+        Bucket: !Ref BucketName
+        Key: !Sub ${OwnerTxtKeyPrefix}/owner.txt
+        ContentType: text
+      Body: !Join [ ",", !Ref SynapseIds ]


### PR DESCRIPTION
Some ancillary changes as well:

* Fixed syntax error in upload and deploy github workflow
* Split the `AWS::S3::Object` resource (owner.txt) into its own template from the S3 bucket template. Since the owner.txt is namespaced, but the bucket name is not, attempting to deploy the same bucket stack with a different namespace will result in the previous namespace's owner.txt being deleted. This appears to be a change necessitated by updates to sceptre. Previously, sceptre did not track custom resources like `AWS::S3::Object`, and so older namespaced resources were never deleted when the stack was deployed in a new namespace. That's since changed, hence the need to separate the Bucket resource from the owner.txt resource in the templates.
* Generalized the new `*-owner-txt.yaml` stacks so that owner.txt can be written to an arbitrary key prefix, not just `namespace/parquet`.