### PR TITLE
[ETL-381] Grant Synapse access to dev parquet bucket

### DIFF
--- a/config/develop/s3-processed-data-bucket-owner-txt.yaml
+++ b/config/develop/s3-processed-data-bucket-owner-txt.yaml
@@ -1,0 +1,13 @@
+template:
+  type: file
+  path: s3-owner-txt.yaml
+stack_name: "{{ stack_group_config.namespace }}-recover-dev-processed-data-bucket-owner-txt"
+dependencies:
+  - develop/cfn-s3objects-macro.yaml
+  - develop/s3-processed-data-bucket.yaml
+parameters:
+  BucketName: !stack_output_external recover-dev-processed-data-bucket::BucketName
+  SynapseIds: "3461799" # recoverETL
+  OwnerTxtKeyPrefix: "{{ stack_group_config.namespace }}/parquet"
+stack_tags:
+  {{ stack_group_config.default_stack_tags }}

--- a/config/develop/s3-processed-data-bucket.yaml
+++ b/config/develop/s3-processed-data-bucket.yaml
@@ -4,3 +4,6 @@ template:
 stack_name: recover-dev-processed-data-bucket
 parameters:
   BucketName: {{ stack_group_config.processed_data_bucket_name }}
+  ConnectToSynapse: "true"
+stack_tags:
+  {{ stack_group_config.default_stack_tags }}

--- a/config/prod/s3-processed-data-bucket-owner-txt.yaml
+++ b/config/prod/s3-processed-data-bucket-owner-txt.yaml
@@ -9,3 +9,5 @@ parameters:
   BucketName: !stack_output_external recover-processed-data-bucket::BucketName
   SynapseIds: "3461799" # recoverETL
   OwnerTxtKeyPrefix: "{{ stack_group_config.namespace }}/parquet"
+stack_tags:
+  {{ stack_group_config.default_stack_tags }}


### PR DESCRIPTION
* Synapse granted permissions to dev parquet bucket (by modifying existing bucket stack) and owner.txt stack created
* Added functionality to `setup_external_storage` script to be able to use Synapse authentication token stored in SSM parameter.
* I tested it on this Synapse folder: https://www.synapse.org/#!Synapse:syn51284492