### PR TITLE
[ETL-385] Grant prod input bucket synapse access

### DIFF
--- a/config/develop/s3-input-bucket.yaml
+++ b/config/develop/s3-input-bucket.yaml
@@ -5,3 +5,5 @@ stack_name: recover-dev-input-bucket
 parameters:
   BucketName: {{ stack_group_config.input_bucket_name }}
   ConnectToSynapse: "true"
+stack_tags:
+  {{ stack_group_config.default_stack_tags }}

--- a/config/prod/s3-input-bucket.yaml
+++ b/config/prod/s3-input-bucket.yaml
@@ -5,5 +5,6 @@ template:
 stack_name: recover-input-bucket
 parameters:
   BucketName: {{ stack_group_config.input_bucket_name }}
+  ConnectToSynapse: "true"
 stack_tags:
   {{ stack_group_config.default_stack_tags }}


### PR DESCRIPTION
**Purpose:** Minor adjustment to add the ability to connect to Synapse and provide STS access to mirror the dev input bucket as well. Followup of this [PR](https://github.com/Sage-Bionetworks/recover/pull/27).