### PR TITLE
[ETL-378] Launch all stacks to "staging" namespace in production account

### DIFF
--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -48,7 +48,6 @@ jobs:
 
   sceptre-deploy-develop:
     name: Deploys branch using sceptre
-    run-name: Deploy sceptre stacks to ${{ env.NAMESPACE }} on dev
     runs-on: ubuntu-latest
     needs: [pre-commit, upload-files]
     environment: develop

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -9,7 +9,6 @@ env:
 jobs:
 
   pre-commit:
-
     name: Run pre-commit hooks against all files
     runs-on: ubuntu-latest
     steps:
@@ -19,7 +18,6 @@ jobs:
 
 
   upload-files:
-
     name: Upload files to S3 bucket in development
     runs-on: ubuntu-latest
     needs: pre-commit
@@ -49,10 +47,10 @@ jobs:
 
 
   sceptre-deploy-branch:
-
     name: Deploy branch using sceptre
     runs-on: ubuntu-latest
     needs: [pre-commit, upload-files]
+    if: github.ref_name != 'main'
     environment: develop
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
@@ -75,4 +73,44 @@ jobs:
         run: echo "NAMESPACE=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
       - name: Deploy sceptre stacks to dev
-        run: pipenv run sceptre --var "namespace=$NAMESPACE" launch develop --yes
+        run: pipenv run sceptre --var "namespace=${{ env.NAMESPACE }}" launch develop --yes
+
+
+sceptre-deploy-main:
+    name: Deploy trunk using sceptre
+    runs-on: ubuntu-latest
+    needs: [pre-commit, upload-files]
+    if: github.ref_name == 'main'
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+
+    strategy:
+      matrix:
+        job-environment:
+          - develop
+          - prod
+
+        include:
+          - job-environment: develop
+            sceptre-environment: develop
+
+          - job-environment: prod
+            sceptre-environment: prod
+
+    environment: ${{ matrix.job-environment }}
+
+    steps:
+      - name: Setup code, pipenv, aws
+        uses: Sage-Bionetworks/action-pipenv-aws-setup@v3
+        with:
+          role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
+          role_session_name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          python_version: ${{ env.PYTHON_VERSION }}
+
+      - name: Create directory for remote sceptre templates
+        run: mkdir -p templates/remote/
+
+      - name: Deploy sceptre stacks
+        run: pipenv run sceptre --var "namespace=${{ env.NAMESPACE }}" launch ${{ matrix.sceptre-environment }} --yes

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -75,7 +75,7 @@ jobs:
         run: pipenv run sceptre --var "namespace=${{ env.NAMESPACE }}" launch develop --yes
 
 
-sceptre-deploy-staging:
+  sceptre-deploy-staging:
     name: Deploys to staging of prod using sceptre
     runs-on: ubuntu-latest
     needs: [pre-commit, upload-files, sceptre-deploy-develop]

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -46,11 +46,10 @@ jobs:
         run: python src/scripts/manage_artifacts/artifacts.py --upload --namespace $NAMESPACE --cfn_bucket ${{ vars.CFN_BUCKET }}
 
 
-  sceptre-deploy-branch:
-    name: Deploy branch using sceptre
+  sceptre-deploy-develop:
+    name: Deploys branch using sceptre
     runs-on: ubuntu-latest
     needs: [pre-commit, upload-files]
-    if: github.ref_name != 'main'
     environment: develop
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
@@ -72,34 +71,20 @@ jobs:
         if: github.ref_name != 'main'
         run: echo "NAMESPACE=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
-      - name: Deploy sceptre stacks to dev
+      - name: "Deploy sceptre stacks to ${{ env.NAMESPACE }} on dev"
         run: pipenv run sceptre --var "namespace=${{ env.NAMESPACE }}" launch develop --yes
 
 
-sceptre-deploy-main:
-    name: Deploy trunk using sceptre
+sceptre-deploy-staging:
+    name: Deploys to staging of prod using sceptre
     runs-on: ubuntu-latest
-    needs: [pre-commit, upload-files]
+    needs: [pre-commit, upload-files, sceptre-deploy-develop]
     if: github.ref_name == 'main'
+    environment: prod
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write
       contents: read
-
-    strategy:
-      matrix:
-        job-environment:
-          - develop
-          - prod
-
-        include:
-          - job-environment: develop
-            sceptre-environment: develop
-
-          - job-environment: prod
-            sceptre-environment: prod
-
-    environment: ${{ matrix.job-environment }}
 
     steps:
       - name: Setup code, pipenv, aws
@@ -112,5 +97,5 @@ sceptre-deploy-main:
       - name: Create directory for remote sceptre templates
         run: mkdir -p templates/remote/
 
-      - name: Deploy sceptre stacks
-        run: pipenv run sceptre --var "namespace=${{ env.NAMESPACE }}" launch ${{ matrix.sceptre-environment }} --yes
+      - name: Deploy sceptre stacks to staging on prod
+        run: pipenv run sceptre --var "namespace=staging" launch prod --yes

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -48,6 +48,7 @@ jobs:
 
   sceptre-deploy-develop:
     name: Deploys branch using sceptre
+    run-name: Deploy sceptre stacks to ${{ env.NAMESPACE }} on dev
     runs-on: ubuntu-latest
     needs: [pre-commit, upload-files]
     environment: develop
@@ -71,7 +72,7 @@ jobs:
         if: github.ref_name != 'main'
         run: echo "NAMESPACE=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
-      - name: "Deploy sceptre stacks to ${{ env.NAMESPACE }} on dev"
+      - name: "Deploy sceptre stacks to dev"
         run: pipenv run sceptre --var "namespace=${{ env.NAMESPACE }}" launch develop --yes
 
 


### PR DESCRIPTION
**Purpose:** Currently this github action workflow will deploy to the "staging" namespace of production upon merge. If we decide we want to switch out of the staging testing workflow, it will be an easy change to have it deploy to the "main" namespace of prod. I also had the deployment to production as a separate job in case we wanted to do anything additional with that GH action job in the future.

Will squash the commits upon merge.