### PR TITLE
[ETL-289] Remove deleted and duplicated samples

### DIFF
--- a/templates/glue-job-role.yaml
+++ b/templates/glue-job-role.yaml
@@ -48,7 +48,7 @@ Resources:
             - iam:GetRolePolicy
             Resource:
             - "*"
-      - PolicyName: ReadWriteInternalS3
+      - PolicyName: ReadWriteS3
         PolicyDocument:
           Version: '2012-10-17'
           Statement:
@@ -65,9 +65,7 @@ Resources:
             - !Sub arn:aws:s3:::${S3IntermediateBucketName}/*
             - !Sub arn:aws:s3:::${S3ParquetBucketName}
             - !Sub arn:aws:s3:::${S3ParquetBucketName}/*
-            - !Sub arn:aws:s3:::${S3ArtifactBucketName}
-            - !Sub arn:aws:s3:::${S3ArtifactBucketName}/*
-      - PolicyName: ReadExternalS3
+      - PolicyName: ReadS3
         PolicyDocument:
           Version: '2012-10-17'
           Statement:
@@ -78,6 +76,8 @@ Resources:
             Resource:
             - !Sub arn:aws:s3:::${S3SourceBucketName}
             - !Sub arn:aws:s3:::${S3SourceBucketName}/*
+            - !Sub arn:aws:s3:::${S3ArtifactBucketName}
+            - !Sub arn:aws:s3:::${S3ArtifactBucketName}/*
       - PolicyName: EC2
         PolicyDocument:
           Version: '2012-10-17'

--- a/templates/glue-workflow.j2
+++ b/templates/glue-workflow.j2
@@ -76,7 +76,7 @@ Resources:
     Properties:
       Actions:
         {% for dataset in datasets %}
-        - JobName: {{ dataset["stackname_prefix"]}}-Job
+        - JobName: !Sub ${Namespace}-{{ dataset["stackname_prefix"]}}-Job
           Arguments: {"--glue-table": {{ "{}".format(dataset["table_name"]) }} }
         {% endfor %}
       Description: This trigger runs after completion of the S3 to JSON job.


### PR DESCRIPTION
This PR covers removing deleted samples. (Removing duplicate samples was already implemented).

If a data type is a HealthKit data type, we check if it has a respective "deleted" table. If it does, we remove records which have a sample key in the "deleted" table. Otherwise, we carry on as usual without removing any records.

I also did some minor clean up in `templates/glue-job-role.yaml` and fixed a bug in `templates/glue-workflow.j2`