### PR TITLE
[ETL-406] Add additional staging resources to production stack group

### DIFF
--- a/config/develop/namespaced/glue-job-compare-parquet.yaml
+++ b/config/develop/namespaced/glue-job-compare-parquet.yaml
@@ -1,0 +1,15 @@
+template:
+  path: glue-job-compare-parquet.yaml
+dependencies:
+  - develop/glue-job-role.yaml
+stack_name: "{{ stack_group_config.namespace }}-glue-job-CompareParquet"
+parameters:
+  JobDescription: Compares parquet datasets between two runs of the recover ETL
+  JobRole: !stack_output_external glue-job-role::RoleArn
+  TempS3Bucket: {{ stack_group_config.processed_data_bucket_name }}
+  S3ScriptBucket: {{ stack_group_config.cloudformation_artifact_bucket_name }}
+  S3ScriptKey: '{{ stack_group_config.namespace }}/src/glue/jobs/compare_parquet_datasets.py'
+  GluePythonShellVersion: "{{ stack_group_config.s3_to_json_python_shell_version }}"
+  GlueVersion: "{{ stack_group_config.s3_to_json_glue_version }}"
+stack_tags:
+  {{ stack_group_config.default_stack_tags }}

--- a/config/develop/namespaced/glue-workflow.yaml
+++ b/config/develop/namespaced/glue-workflow.yaml
@@ -10,6 +10,9 @@ parameters:
   ParquetBucketName: {{ stack_group_config.processed_data_bucket_name }}
   GlueDatabase: !stack_output_external "{{ stack_group_config.namespace }}-glue-tables::DatabaseName"
   S3ToJsonJobName: !stack_output_external "{{ stack_group_config.namespace }}-glue-job-S3ToJsonS3::JobName"
+  CompareParquetJobName: !stack_output_external "{{ stack_group_config.namespace }}-glue-job-CompareParquet::JobName"
+  CompareParquetStagingNamespace: {{ stack_group_config.namespace }}
+  CompareParquetMainNamespace: "main"
 stack_tags:
   {{ stack_group_config.default_stack_tags }}
 sceptre_user_data:

--- a/config/develop/namespaced/glue-workflow.yaml
+++ b/config/develop/namespaced/glue-workflow.yaml
@@ -4,6 +4,8 @@ stack_name: "{{ stack_group_config.namespace }}-glue-workflow"
 dependencies:
   - develop/namespaced/glue-tables.yaml
   - develop/namespaced/glue-job-S3ToJsonS3.yaml
+  - develop/namespaced/glue-job-JSONToParquet.yaml
+  - develop/namespaced/glue-job-compare-parquet.yaml
 parameters:
   Namespace: {{ stack_group_config.namespace }}
   JsonBucketName: {{ stack_group_config.intermediate_bucket_name }}

--- a/config/prod/namespaced/glue-job-compare-parquet.yaml
+++ b/config/prod/namespaced/glue-job-compare-parquet.yaml
@@ -1,0 +1,15 @@
+template:
+  path: glue-job-compare-parquet.yaml
+dependencies:
+  - develop/glue-job-role.yaml
+stack_name: "{{ stack_group_config.namespace }}-glue-job-CompareParquet"
+parameters:
+  JobDescription: Compares parquet datasets between two runs of the recover ETL
+  JobRole: !stack_output_external glue-job-role::RoleArn
+  TempS3Bucket: {{ stack_group_config.processed_data_bucket_name }}
+  S3ScriptBucket: {{ stack_group_config.cloudformation_artifact_bucket_name }}
+  S3ScriptKey: '{{ stack_group_config.namespace }}/src/glue/jobs/compare_parquet_datasets.py'
+  GluePythonShellVersion: "{{ stack_group_config.s3_to_json_python_shell_version }}"
+  GlueVersion: "{{ stack_group_config.s3_to_json_glue_version }}"
+stack_tags:
+  {{ stack_group_config.default_stack_tags }}

--- a/config/prod/namespaced/glue-workflow.yaml
+++ b/config/prod/namespaced/glue-workflow.yaml
@@ -4,6 +4,8 @@ stack_name: "{{ stack_group_config.namespace }}-glue-workflow"
 dependencies:
   - prod/namespaced/glue-tables.yaml
   - prod/namespaced/glue-job-S3ToJsonS3.yaml
+  - prod/namespaced/glue-job-JSONToParquet.yaml
+  - prod/namespaced/glue-job-compare-parquet.yaml
 parameters:
   Namespace: {{ stack_group_config.namespace }}
   JsonBucketName: {{ stack_group_config.intermediate_bucket_name }}

--- a/config/prod/namespaced/glue-workflow.yaml
+++ b/config/prod/namespaced/glue-workflow.yaml
@@ -10,6 +10,9 @@ parameters:
   ParquetBucketName: {{ stack_group_config.processed_data_bucket_name }}
   GlueDatabase: !stack_output_external "{{ stack_group_config.namespace }}-glue-tables::DatabaseName"
   S3ToJsonJobName: !stack_output_external "{{ stack_group_config.namespace }}-glue-job-S3ToJsonS3::JobName"
+  CompareParquetJobName: !stack_output_external "{{ stack_group_config.namespace }}-glue-job-CompareParquet::JobName"
+  CompareParquetStagingNamespace: "staging"
+  CompareParquetMainNamespace: "main"
 stack_tags:
   {{ stack_group_config.default_stack_tags }}
 sceptre_user_data:

--- a/templates/glue-job-compare-parquet.yaml
+++ b/templates/glue-job-compare-parquet.yaml
@@ -1,0 +1,86 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: The glue job for comparing parquet datasets
+
+Parameters:
+
+  JobDescription:
+    Type: String
+    Description: A fuller description of what the job does.
+    Default: ''
+
+  JobRole:
+    Type: String
+    Description: The name or ARN of the IAM role that will run this job.
+
+  S3ScriptBucket:
+    Type: String
+    Description: The name of the S3 bucket where the script file is located.
+
+  S3ScriptKey:
+    Type: String
+    Description: The bucket key where the script file is located.
+
+  MaxCapacity:
+    Type: Number
+    Description: How many DPUs to allot to this job.
+    Default: 1
+
+  MaxConcurrentRuns:
+    Type: Number
+    Description: >-
+      Number of this type of glue job that can be run at same time (double).
+    Default: 150
+
+  MaxRetries:
+    Type: Number
+    Description: How many times to retry the job if it fails (integer).
+    Default: 0 # TODO change this to 1 after initial development
+
+  GluePythonShellVersion:
+    Type: String
+    Description: The version of Python to use for the Glue Python Shell job
+
+  GlueVersion:
+    Type: String
+    Description: The version of glue to use for this job
+
+  TimeoutInMinutes:
+    Type: Number
+    Description: The job timeout in minutes (integer).
+    Default: 120
+
+  TempS3Bucket:
+    Type: String
+    Description: The name of the S3 bucket where temporary files and logs are written.
+
+Resources:
+
+  GlueJob:
+      Type: AWS::Glue::Job
+      Properties:
+        Command:
+          Name: pythonshell
+          PythonVersion: !Ref GluePythonShellVersion
+          ScriptLocation: !Sub s3://${S3ScriptBucket}/${S3ScriptKey}
+        DefaultArguments:
+          --TempDir: !Sub s3://${TempS3Bucket}/tmp
+          --job-language: python
+          --enable-continuous-cloudwatch-log: true
+          --enable-metrics: true
+        Description: !Ref JobDescription
+        GlueVersion: !Ref GlueVersion
+        ExecutionProperty:
+          MaxConcurrentRuns: !Ref MaxConcurrentRuns
+        MaxCapacity: !Ref MaxCapacity
+        MaxRetries: !Ref MaxRetries
+        Name: !Sub '${AWS::StackName}-Job'
+        Role: !Ref JobRole
+        Timeout: !Ref TimeoutInMinutes
+
+Outputs:
+
+  JobName:
+    Value: !Ref GlueJob
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-JobName'

--- a/templates/glue-workflow.j2
+++ b/templates/glue-workflow.j2
@@ -37,6 +37,18 @@ Parameters:
     Type: String
     Description: The name of the S3 To JSON Job
 
+  CompareParquetJobName:
+    Type: String
+    Description: The name of the Compare Parquet glue job
+
+  CompareParquetStagingNamespace:
+    Type: String
+    Description: the name of the "staging" namespace
+
+  CompareParquetMainNamespace:
+    Type: String
+    Description: The name of the "main" namespace
+
 Resources:
 
   {% set datasets = [] %}
@@ -86,6 +98,27 @@ Resources:
         - JobName: !Ref S3ToJsonJobName
           State: SUCCEEDED
           LogicalOperator: EQUALS
+      StartOnCreation: true
+      WorkflowName: !Ref PrimaryWorkflow
+
+  JsontoParquetCompleteTrigger:
+    Type: AWS::Glue::Trigger
+    Properties:
+      Actions:
+        - JobName: !Ref CompareParquetJobName
+          Arguments:
+            "--main-namespace": !Ref CompareParquetMainNamespace
+            "--staging-namespace": !Ref CompareParquetStagingNamespace
+            "--parquet-bucket": !Ref ParquetBucketName
+      Description: This trigger runs after completion of all JSON to Parquet jobs
+      Type: CONDITIONAL
+      Predicate:
+        Conditions:
+          {% for dataset in datasets %}
+          - JobName: !Sub "${Namespace}-{{ dataset["stackname_prefix"] }}-Job"
+            State: SUCCEEDED
+            LogicalOperator: EQUALS
+          {% endfor %}
       StartOnCreation: true
       WorkflowName: !Ref PrimaryWorkflow
 

--- a/templates/glue-workflow.j2
+++ b/templates/glue-workflow.j2
@@ -77,6 +77,7 @@ Resources:
   InitialTrigger:
     Type: AWS::Glue::Trigger
     Properties:
+      Name: !Sub "${Namespace}-InitialTrigger"
       Actions:
         - JobName: !Ref S3ToJsonJobName
       Description: This is the first trigger in the primary workflow.
@@ -86,6 +87,7 @@ Resources:
   S3ToJsonCompleteTrigger:
     Type: AWS::Glue::Trigger
     Properties:
+      Name: !Sub "${Namespace}-S3ToJsonCompleteTrigger"
       Actions:
         {% for dataset in datasets %}
         - JobName: !Sub ${Namespace}-{{ dataset["stackname_prefix"]}}-Job
@@ -104,6 +106,7 @@ Resources:
   JsontoParquetCompleteTrigger:
     Type: AWS::Glue::Trigger
     Properties:
+      Name: !Sub "${Namespace}-JsontoParquetCompleteTrigger"
       Actions:
         - JobName: !Ref CompareParquetJobName
           Arguments:
@@ -119,6 +122,7 @@ Resources:
             State: SUCCEEDED
             LogicalOperator: EQUALS
           {% endfor %}
+        Logical: AND
       StartOnCreation: true
       WorkflowName: !Ref PrimaryWorkflow
 


### PR DESCRIPTION
**Purpose:** I created this draft PR before getting into more nitty gritty edits/testing as it's waiting on [ETL-409](https://sagebionetworks.jira.com/browse/ETL-409) to get some feedback about the structuring of our cloudformation resources and if there were additional specs we expected from the two resources to be added as part of this ticket. I have added the following to both our development and production stacks:

-  compare parquet glue job
-  compare parquet glue trigger (triggers the above job)

I added the compare parquet glue trigger to our current glue-workflow instead of creating it as an additional resource. Once the compare parquet python script is complete/merged, should be able to properly test this. 