### PR TITLE
[ETL-434] Modify S3 to Glue Lambda code to use S3 event notifications

### DIFF
--- a/config/develop/namespaced/s3-to-glue-lambda.yaml
+++ b/config/develop/namespaced/s3-to-glue-lambda.yaml
@@ -10,5 +10,4 @@ stack_name: '{{ stack_group_config.namespace }}-lambda-S3ToGlue'
 stack_tags: {{ stack_group_config.default_stack_tags }}
 parameters:
   S3ToGlueRoleArn: !stack_output_external s3-to-glue-lambda-role::RoleArn
-  S3SourceBucketName: {{ stack_group_config.input_bucket_name }}
   PrimaryWorkflowName: !stack_output_external "{{ stack_group_config.namespace }}-glue-workflow::WorkflowName"

--- a/config/prod/namespaced/s3-to-glue-lambda.yaml
+++ b/config/prod/namespaced/s3-to-glue-lambda.yaml
@@ -10,5 +10,4 @@ stack_name: '{{ stack_group_config.namespace }}-lambda-S3ToGlue'
 stack_tags: {{ stack_group_config.default_stack_tags }}
 parameters:
   S3ToGlueRoleArn: !stack_output_external s3-to-glue-lambda-role::RoleArn
-  S3SourceBucketName: {{ stack_group_config.input_bucket_name }}
   PrimaryWorkflowName: !stack_output_external "{{ stack_group_config.namespace }}-glue-workflow::WorkflowName"

--- a/src/lambda_function/s3_to_glue/app.py
+++ b/src/lambda_function/s3_to_glue/app.py
@@ -1,74 +1,32 @@
 import os
 import json
 import logging
-import datetime
-from dateutil import parser
-
 import boto3
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-
-def query_files_to_submit(
-    objects: dict, files_to_submit: list, trigger_event_date: datetime
-):
-    """Queries the files in bucket for ones with the same
-    date as the trigger event
-
-    Args:
-        objects (dict): bucket objects' metadata info
-        files_to_submit (list): fielsto submit from source s3 bucket
-        trigger_event_date (datetime): _description_
-
-    Returns:
-        list: List of dictionaries containing source_bucket and source_key
-        for each file to submit from the source s3 bucket
+def submit_s3_to_json_workflow(messages: list[dict[str,str]], workflow_name):
     """
-    files_current = objects["Contents"]
-    logger.info("Querying S3 bucket for new data from source")
-
-    # query bucket for new/updated files
-    for fi in files_current:
-        # skip objects with no last modified
-        if "LastModified" not in fi:
-            continue
-        file_date = fi["LastModified"].date()
-        # if object's last modified date is same as today
-        if file_date == trigger_event_date:
-            # grab Bucket and Key
-            message_parameters = {
-                "source_bucket": objects["Name"],
-                "source_key": fi["Key"],
-            }
-            files_to_submit.append(message_parameters)
-        else:
-            pass
-    return files_to_submit
-
-
-def submit_s3_to_json_workflow(files_to_submit: list):
-    """Submits list of dicts with keys source_bucket and source_key
-    for the new files added to the S3 to Json glue workflow
+    Submits list of dicts with keys `source_bucket` and `source_key`
+    to the S3 to JSON Glue workflow.
 
     Args:
         workflow_name (str): name of the glue workflow to submit to
-        files_to_submit (list): files from source S3 bucket to submit
-        to glue workflow
+        messages (list): objects from source S3 bucket to submit
+        to Glue workflow.
 
     Returns:
         (None)
     """
-    workflow_name = os.environ["PRIMARY_WORKFLOW_NAME"]
     glue_client = boto3.client("glue")
-    logger.info(f"Starting workflow run for workflow {workflow_name}")
+    logger.info(f"Starting workflow run for {workflow_name}")
     workflow_run = glue_client.start_workflow_run(Name=workflow_name)
     glue_client.put_workflow_run_properties(
         Name=workflow_name,
         RunId=workflow_run["RunId"],
-        RunProperties={"messages": json.dumps(files_to_submit)},
+        RunProperties={"messages": json.dumps(messages)},
     )
-    return None
 
 
 def lambda_handler(event, context):
@@ -86,20 +44,19 @@ def lambda_handler(event, context):
     Returns:
         (None) Submits new file records to a Glue workflow.
     """
-    s3 = boto3.client("s3")
-    source_bucket_name = os.environ["S3_SOURCE_BUCKET_NAME"]
-    trigger_event_date = parser.isoparse(event["time"]).date()
-    objects = s3.list_objects_v2(Bucket=source_bucket_name)
-    files_to_submit = []
-    if "Contents" in objects:
-        files_to_submit = query_files_to_submit(
-            objects, files_to_submit, trigger_event_date
+    messages = []
+    for record in event["Records"]:
+        bucket_name = record["s3"]["bucket"]["name"]
+        object_key = record["s3"]["object"]["key"]
+        message = {"source_bucket": bucket_name, "source_key": object_key}
+        if "owner.txt" not in object_key:
+            messages.append(message)
+    if len(messages) > 0:
+        logger.info(
+                "Submitting the following files to "
+                f"{os.environ['PRIMARY_WORKFLOW_NAME']}: {json.dumps(messages)}"
         )
-    else:
-        logger.info(f"No files found in {source_bucket_name} bucket")
-
-    # submit new files to new glue workflow
-    if len(files_to_submit) > 0:
-        submit_s3_to_json_workflow(files_to_submit)
-    else:
-        logger.info(f"No new files to be submitted in {source_bucket_name} bucket")
+        submit_s3_to_json_workflow(
+                messages = messages,
+                workflow_name = os.environ["PRIMARY_WORKFLOW_NAME"]
+        )

--- a/src/lambda_function/s3_to_glue/app.py
+++ b/src/lambda_function/s3_to_glue/app.py
@@ -1,3 +1,9 @@
+"""
+This Lambda app responds to an S3 event notification and starts a Glue workflow.
+The Glue workflow name is set by the environment variable `PRIMARY_WORKFLOW_NAME`.
+Subsequently, the S3 objects which were contained in the event are written as a
+JSON string to the `messages` workflow run property.
+"""
 import os
 import json
 import logging

--- a/src/lambda_function/template.yaml
+++ b/src/lambda_function/template.yaml
@@ -11,16 +11,6 @@ Parameters:
     Type: String
     Description: Arn for the S3 to Glue Lambda Role
 
-  Schedule:
-    Description: >
-      Schedule to execute the lambda function
-    Type: String
-    Default: cron(59 23 * * ? *)
-
-  S3SourceBucketName:
-    Type: String
-    Description: Name of the S3 bucket where source data are stored.
-
   PrimaryWorkflowName:
     Type: String
     Description: >
@@ -44,13 +34,7 @@ Resources:
       Timeout: 30
       Environment:
         Variables:
-          S3_SOURCE_BUCKET_NAME: !Ref S3SourceBucketName
           PRIMARY_WORKFLOW_NAME: !Ref PrimaryWorkflowName
-      Events:
-        DailyTrigger:
-          Type: Schedule
-          Properties:
-            Schedule: !Ref Schedule
 
 Outputs:
   S3ToGlueFunctionArn:

--- a/tests/test_s3_to_glue_lambda.py
+++ b/tests/test_s3_to_glue_lambda.py
@@ -68,4 +68,3 @@ class TestS3ToGlueLambda:
                 messages=test_messages,
                 workflow_name="example-workflow"
         )
-

--- a/tests/test_s3_to_glue_lambda.py
+++ b/tests/test_s3_to_glue_lambda.py
@@ -1,108 +1,71 @@
-import os
-import datetime
-from dateutil.tz import tzutc
-from dateutil import parser
-
-import boto3
 import pytest
-
 from src.lambda_function.s3_to_glue import app
 
+class MockGlueClient:
+    def start_workflow_run(*args, **kwargs):
+        return {"RunId": "example"}
 
-@pytest.fixture
-def test_empty_s3_bucket_objects():
-    test_empty_s3_bucket_objects = {
-        "ResponseMetadata": {
-            "RequestId": "TEST",
-            "HostId": "TEST",
-            "HTTPStatusCode": 200,
-            "HTTPHeaders": {},
-            "RetryAttempts": 0,
-        },
-        "IsTruncated": False,
-        "Name": "test-bucket",
-        "Prefix": "",
-        "MaxKeys": 1000,
-        "EncodingType": "url",
-        "KeyCount": 0,
-    }
-    return test_empty_s3_bucket_objects
+    def put_workflow_run_properties(*args, **kwargs):
+        return {}
 
+class TestS3ToGlueLambda:
 
-@pytest.fixture
-def test_s3_bucket_objects():
-    test_s3_bucket_objects = {
-        "ResponseMetadata": {
-            "RequestId": "TEST",
-            "HostId": "TEST",
-            "HTTPStatusCode": 200,
-            "HTTPHeaders": {},
-            "RetryAttempts": 0,
-        },
-        "IsTruncated": False,
-        "Name": "test-bucket",
-        "Prefix": "",
-        "MaxKeys": 1000,
-        "EncodingType": "url",
-        "KeyCount": 0,
-        "Contents": [
+    @pytest.fixture
+    def test_s3_event(self):
+        s3_event = {
+          "Records": [
             {
-                "Key": "2023-01-03T20--19--TEST",
-                "LastModified": datetime.datetime(
-                    2023, 1, 19, 21, 13, 23, tzinfo=tzutc()
-                ),
-                "ETag": '"TEST"',
-                "Size": 100,
-                "StorageClass": "STANDARD",
+              "eventVersion": "2.0",
+              "eventSource": "aws:s3",
+              "awsRegion": "us-east-1",
+              "eventTime": "1970-01-01T00:00:00.000Z",
+              "eventName": "ObjectCreated:Put",
+              "userIdentity": {
+                "principalId": "EXAMPLE"
+              },
+              "requestParameters": {
+                "sourceIPAddress": "127.0.0.1"
+              },
+              "responseElements": {
+                "x-amz-request-id": "EXAMPLE123456789",
+                "x-amz-id-2": "EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH"
+              },
+              "s3": {
+                "s3SchemaVersion": "1.0",
+                "configurationId": "testConfigRule",
+                "bucket": {
+                  "name": "recover-dev-input-data",
+                  "ownerIdentity": {
+                    "principalId": "EXAMPLE"
+                  },
+                  "arn": "arn:aws:s3:::bucket_arn"
+                },
+                "object": {
+                  "key": "main/2023-01-12T22--02--17Z_77fefff8-b0e2-4c1b-b0c5-405554c92368",
+                  "size": 1024,
+                  "eTag": "0123456789abcdef0123456789abcdef",
+                  "sequencer": "0A1B2C3D4E5F678901"
+                }
+              }
             }
-        ],
-    }
-    return test_s3_bucket_objects
-
-
-@pytest.fixture
-def test_trigger_event():
-    test_trigger_event = {
-        "version": "0",
-        "id": "TEST",
-        "detail-type": "Scheduled Event",
-        "source": "aws.events",
-        "account": "TEST",
-        "time": "2023-01-19T23:21:00Z",
-        "region": "us-east-1",
-        "resources": [],
-        "detail": {},
-    }
-    return test_trigger_event
-
-
-def test_query_files_to_submit_success(test_s3_bucket_objects, test_trigger_event):
-    test_submit_files = app.query_files_to_submit(
-        objects=test_s3_bucket_objects,
-        files_to_submit=[],
-        trigger_event_date=parser.isoparse(test_trigger_event["time"]).date(),
-    )
-    assert test_submit_files == [
-        {
-            "source_bucket": test_s3_bucket_objects["Name"],
-            "source_key": test_s3_bucket_objects["Contents"][0]["Key"],
+          ]
         }
-    ]
+        return s3_event
 
+    @pytest.fixture
+    def test_messages(self):
+        messages = [
+                {
+                    "source_bucket": "recover-dev-input-data",
+                    "source_object": "main/2023-01-12T22--02--17Z_77fefff8-b0e2-4c1b-b0c5-405554c92368"
+                }
+        ]
+        return messages
 
-def test_no_files_to_submit_on_date(test_s3_bucket_objects):
-    test_submit_files = app.query_files_to_submit(
-        objects=test_s3_bucket_objects,
-        files_to_submit=[],
-        trigger_event_date=datetime.datetime.now().date(),
-    )
-    assert test_submit_files == []
+    def test_submit_s3_to_json_workflow(self, test_messages, monkeypatch):
+        monkeypatch.setattr("boto3.client", lambda x: MockGlueClient())
+        app.submit_s3_to_json_workflow(
+                messages=test_messages,
+                workflow_name="example-workflow"
+        )
 
-
-def test_empty_bucket_contents(test_trigger_event):
-    test_submit_files = app.query_files_to_submit(
-        objects={"Contents": []},
-        files_to_submit=[],
-        trigger_event_date=parser.isoparse(test_trigger_event["time"]).date(),
-    )
-    assert test_submit_files == []


### PR DESCRIPTION
Effectively a rewrite of our S3 to Glue Lambda to use S3 event notifications. We skirt the owner.txt issues identified in the JIRA ticket by ignoring any objects which contain "owner.txt" in their name.