### PR TITLE
[ETL-374] Fix failing test for setup_external_storage

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
 FROM amazon/aws-glue-libs:glue_libs_4.0.0_image_01
 
-RUN pip3 install synapseclient~=2.7 pyarrow~=11.0 pytest-datadir
+RUN pip3 install moto~=4.1 synapseclient~=2.7 pyarrow~=11.0 datacompy~=0.8 pytest-datadir
 ENTRYPOINT ["bash", "-l"]

--- a/tests/README.md
+++ b/tests/README.md
@@ -56,10 +56,23 @@ pytest with other tests because they have to be run in a Dockerfile:
 - test_s3_to_glue_lambda.py
 - test_setup_external_storage.py
 
-Example)
+
+#### Running tests for lambda
 Run the following command from the repo root to run tests for the lambda function (in develop).
-You can run this locally or inside the docker image.
 
 ```shell script
 python3 -m pytest tests/test_s3_to_glue_lambda.py -v
+```
+
+#### Running tests for setup external storage
+Run the following command from the repo root to run the integration test for the setup external storage script to check that the STS
+access has been set for a given synapse folder (in develop).
+
+This test takes in two command line arguments:
+
+- test-synapse-folder-id - synapse id of the folder to check STS access for
+- test-ssm-parameter - ssm parameter to get AWS credentials for otherwise leave blank and it will pull credentials from the environment
+
+```shell script
+python3 -m pytest tests/test_setup_external_storage.py --test-synapse-folder-id <put_synapse_folder_id_here> --test-ssm-parameter <put_ssm_parameter_here_or_leave_blank>
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,5 +259,15 @@ def staging_dataset_empty():
 
 
 def pytest_addoption(parser):
-    parser.addoption("--test-synapse-folder-id", action="store", default=None)
-    parser.addoption("--test-ssm-parameter", action="store", default=None)
+    parser.addoption(
+        "--test-synapse-folder-id",
+        action="store",
+        default="syn27558289",
+        help="ID of the synapse folder to check STS access. Defaults to test folder",
+    )
+    parser.addoption(
+        "--test-ssm-parameter",
+        action="store",
+        default=None,
+        help="The SSM parameter to use to check STS access. Optional",
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -262,8 +262,8 @@ def pytest_addoption(parser):
     parser.addoption(
         "--test-synapse-folder-id",
         action="store",
-        default="syn27558289",
-        help="ID of the synapse folder to check STS access. Defaults to test folder",
+        default=None,
+        help="ID of the synapse folder to check STS access. Required.",
     )
     parser.addoption(
         "--test-ssm-parameter",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -256,3 +256,8 @@ def staging_dataset_with_empty_columns():
 @pytest.fixture()
 def staging_dataset_empty():
     return pd.DataFrame()
+
+
+def pytest_addoption(parser):
+    parser.addoption("--test-synapse-folder-id", action="store", default=None)
+    parser.addoption("--test-ssm-parameter", action="store", default=None)

--- a/tests/test_setup_external_storage.py
+++ b/tests/test_setup_external_storage.py
@@ -8,12 +8,12 @@ from src.scripts.setup_external_storage import setup_external_storage
 
 @pytest.fixture()
 def test_synapse_folder_id(pytestconfig):
-    return pytestconfig.getoption("test_synapse_folder_id")
+    yield pytestconfig.getoption("test_synapse_folder_id")
 
 
 @pytest.fixture()
 def test_ssm_parameter(pytestconfig):
-    return pytestconfig.getoption("test_ssm_parameter")
+    yield pytestconfig.getoption("test_ssm_parameter")
 
 
 def test_setup_external_storage_success(test_synapse_folder_id, test_ssm_parameter):
@@ -26,13 +26,3 @@ def test_setup_external_storage_success(test_synapse_folder_id, test_ssm_paramet
     token = test_synapse_client.get_sts_storage_token(
         entity=test_synapse_folder_id, permission="read_only", output_format="json"
     )
-    # Pass STS credentials to Arrow filesystem interface
-    s3 = fs.S3FileSystem(
-        access_key=token["accessKeyId"],
-        secret_key=token["secretAccessKey"],
-        session_token=token["sessionToken"],
-        region="us-east-1",
-    )
-    # get file info
-    base_s3_uri = "{}/{}".format(token["bucket"], token["baseKey"])
-    datasets = s3.get_file_info(fs.FileSelector(base_s3_uri, recursive=False))

--- a/tests/test_setup_external_storage.py
+++ b/tests/test_setup_external_storage.py
@@ -16,6 +16,7 @@ def test_ssm_parameter(pytestconfig):
     yield pytestconfig.getoption("test_ssm_parameter")
 
 
+@pytest.mark.integration()
 def test_setup_external_storage_success(test_synapse_folder_id, test_ssm_parameter):
     """This test tests that it can get the STS token credentials and view and list the
     files in the S3 bucket location to verify that it has access"""


### PR DESCRIPTION
**Purpose:** This fixes the failing integration test for `setup_external_storage.py` and allows for the addition of command line arguments for running the test so that you are able to test STS access for multiple synapse folders that had STS access setup rather than a hard coded folder. 