### PR TITLE
[ETL-435] Deny Synapse-connected bucket access outside us-east-1

### DIFF
--- a/templates/s3-bucket.yaml
+++ b/templates/s3-bucket.yaml
@@ -83,6 +83,19 @@ Resources:
                 - 's3:*MultipartUpload*'
               Resource: !Sub ${Bucket.Arn}/*
             - !Ref AWS::NoValue
+          - !If
+            - ConnectToSynapse
+            - Sid: RestrictAccessByRegion
+              Effect: Deny
+              NotAction:
+                - 'iam:*'
+                - 'support:*'
+              Principal: '*'
+              Resource: !Sub ${Bucket.Arn}/*
+              Condition:
+                StringNotEquals:
+                  aws:RequestedRegion: 'us-east-1'
+            - !Ref AWS::NoValue
 
 Outputs:
 


### PR DESCRIPTION
This bucket policy update blocks any type of access to a Synapse connected S3 bucket (pre/post ETL buckets) if:

* The request region is not us-east-1 OR
* The request comes from IAM or Support services.

Side note: IAM and Support are global services that have a physical endpoint in us-east-1, so it's not strictly necessary to list them here. But if we ever reuse this code in a different region it's important to allow access to these services.