### PR TITLE
Include digital health service account in owner.txt

### DIFF
--- a/config/develop/namespaced/s3-input-bucket-owner-txt.yaml
+++ b/config/develop/namespaced/s3-input-bucket-owner-txt.yaml
@@ -7,5 +7,5 @@ dependencies:
   - develop/s3-input-bucket.yaml
 parameters:
   BucketName: !stack_output_external recover-dev-input-bucket::BucketName
-  SynapseIds: "3461799,3357179" # RecoverETL and meghasyam
+  SynapseIds: "3461799,3455604" # RecoverETL and synapse-service-sysbio-recover-data-storage-01
   OwnerTxtKeyPrefix: {{ stack_group_config.namespace }}

--- a/config/prod/namespaced/s3-input-bucket-owner-txt.yaml
+++ b/config/prod/namespaced/s3-input-bucket-owner-txt.yaml
@@ -7,5 +7,5 @@ dependencies:
   - prod/s3-input-bucket.yaml
 parameters:
   BucketName: !stack_output_external recover-input-bucket::BucketName
-  SynapseIds: "3461799,3357179" # RecoverETL and meghasyam
+  SynapseIds: "3461799,3455604" # RecoverETL and synapse-service-sysbio-recover-data-storage-01
   OwnerTxtKeyPrefix: {{ stack_group_config.namespace }}


### PR DESCRIPTION
Allows the service account to use the pre-ETL bucket in both develop and production as a Synapse external storage location.