### PR TITLE
Add digital health service account to processed bucket owner.txt

### DIFF
--- a/config/develop/s3-processed-data-bucket-owner-txt.yaml
+++ b/config/develop/s3-processed-data-bucket-owner-txt.yaml
@@ -7,7 +7,7 @@ dependencies:
   - develop/s3-processed-data-bucket.yaml
 parameters:
   BucketName: !stack_output_external recover-dev-processed-data-bucket::BucketName
-  SynapseIds: "3461799" # recoverETL
+  SynapseIds: "3461799,3455604" # RecoverETL and synapse-service-sysbio-recover-data-storage-01
   OwnerTxtKeyPrefix: "{{ stack_group_config.namespace }}/parquet"
 stack_tags:
   {{ stack_group_config.default_stack_tags }}

--- a/config/prod/s3-processed-data-bucket-owner-txt.yaml
+++ b/config/prod/s3-processed-data-bucket-owner-txt.yaml
@@ -7,7 +7,7 @@ dependencies:
   - prod/s3-processed-data-bucket.yaml
 parameters:
   BucketName: !stack_output_external recover-processed-data-bucket::BucketName
-  SynapseIds: "3461799" # recoverETL
+  SynapseIds: "3461799,3455604" # RecoverETL and synapse-service-sysbio-recover-data-storage-01
   OwnerTxtKeyPrefix: "{{ stack_group_config.namespace }}/parquet"
 stack_tags:
   {{ stack_group_config.default_stack_tags }}


### PR DESCRIPTION
Related to #53 .

Let's allow digital health to use the processed data buckets as Synapse external storage locations.