### PR TITLE
[ETL-446] Add upload-and-deploy-to-prod-main workflow

### DIFF
--- a/.github/workflows/upload-and-deploy-to-prod-main.yaml
+++ b/.github/workflows/upload-and-deploy-to-prod-main.yaml
@@ -71,7 +71,7 @@ jobs:
         run: pipenv run sceptre --var "namespace=${{ env.NAMESPACE }}" launch prod --yes
 
       - name: Configure S3 to Glue lambda with S3 trigger
-        uses: actions/invoke-aws-lambda@v3
+        uses: gagoar/invoke-aws-lambda@v3
         with:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/upload-and-deploy-to-prod-main.yaml
+++ b/.github/workflows/upload-and-deploy-to-prod-main.yaml
@@ -1,0 +1,82 @@
+name: upload-and-deploy-to-prod-main
+
+description: >-
+  Upload artifacts and deploy stacks to main when a new tag is pushed.
+  Tags must be formatted using semantic versioning.
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+env:
+  NAMESPACE: main
+  PYTHON_VERSION: 3.9
+
+jobs:
+
+  pre-commit:
+    name: Run pre-commit hooks against all files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - uses: pre-commit/action@v3.0.0
+
+
+  upload-files:
+    name: Upload files to S3 bucket in prod/main
+    runs-on: ubuntu-latest
+    needs: pre-commit
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    environment: prod
+    steps:
+
+      - name: Setup code, pipenv, aws
+        uses: Sage-Bionetworks/action-pipenv-aws-setup@v3
+        with:
+          role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
+          role_session_name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          python_version: ${{ env.PYTHON_VERSION }}
+
+      - name: Copy files to templates bucket
+        run: python src/scripts/manage_artifacts/artifacts.py --upload --namespace $NAMESPACE --cfn_bucket ${{ vars.CFN_BUCKET }}
+
+
+  sceptre-deploy-main:
+    name: Deploys to prod/main using sceptre
+    runs-on: ubuntu-latest
+    needs: [pre-commit, upload-files]
+    environment: prod
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Setup code, pipenv, aws
+        uses: Sage-Bionetworks/action-pipenv-aws-setup@v3
+        with:
+          role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
+          role_session_name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          python_version: ${{ env.PYTHON_VERSION }}
+
+      - name: Create directory for remote sceptre templates
+        run: mkdir -p templates/remote/
+
+      - name: Deploy sceptre stacks to prod/main
+        run: pipenv run sceptre --var "namespace=${{ env.NAMESPACE }}" launch prod --yes
+
+      - name: Configure S3 to Glue lambda with S3 trigger
+        uses: actions/invoke-aws-lambda@v3
+        with:
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
+          REGION: ${{ env.AWS_REGION }}
+          FunctionName: ${{ env.NAMESPACE }}-S3EventConfig
+          Payload: '{"RequestType": "Create"}'
+          LogType: Tail

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -1,6 +1,9 @@
 name: upload-and-deploy
 
-on: [push]
+on:
+  push:
+    branches: "*"
+    tags-ignore: "*"
 
 env:
   NAMESPACE: main

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -74,6 +74,16 @@ jobs:
       - name: "Deploy sceptre stacks to dev"
         run: pipenv run sceptre --var "namespace=${{ env.NAMESPACE }}" launch develop --yes
 
+      - name: Configure S3 to Glue lambda with S3 trigger
+        uses: gagoar/invoke-aws-lambda@v3
+        with:
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
+          REGION: ${{ env.AWS_REGION }}
+          FunctionName: ${{ env.NAMESPACE }}-S3EventConfig
+          Payload: '{"RequestType": "Create"}'
+          LogType: Tail
 
   sceptre-deploy-staging:
     name: Deploys to staging of prod using sceptre

--- a/src/lambda_function/s3_event_config/template.yaml
+++ b/src/lambda_function/s3_event_config/template.yaml
@@ -33,6 +33,7 @@ Resources:
   S3EventConfigFunction:
     Type: AWS::Serverless::Function
     Properties:
+      FunctionName: !Sub "${Namespace}-S3EventConfig"
       PackageType: Zip
       CodeUri: ./
       Handler: app.lambda_handler

--- a/src/lambda_function/s3_event_config/template.yaml
+++ b/src/lambda_function/s3_event_config/template.yaml
@@ -46,13 +46,6 @@ Resources:
           S3_TO_GLUE_FUNCTION_ARN: !Ref S3ToGlueFunctionArn
           BUCKET_KEY_PREFIX: !Ref Namespace
 
-  LambdaInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !GetAtt S3EventConfigFunction.Arn
-      Action: lambda:InvokeFunction
-      Principal: !Ref 'AWS::AccountId'
-
 Outputs:
   S3EventConfigFunctionArn:
     Description: Arn of the S3EventConfigFunction function

--- a/src/lambda_function/s3_event_config/template.yaml
+++ b/src/lambda_function/s3_event_config/template.yaml
@@ -46,6 +46,13 @@ Resources:
           S3_TO_GLUE_FUNCTION_ARN: !Ref S3ToGlueFunctionArn
           BUCKET_KEY_PREFIX: !Ref Namespace
 
+  LambdaInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt S3EventConfigFunction.Arn
+      Action: lambda:InvokeFunction
+      Principal: !Ref 'AWS::AccountId'
+
 Outputs:
   S3EventConfigFunctionArn:
     Description: Arn of the S3EventConfigFunction function


### PR DESCRIPTION
This ticket was for work needed to configure the S3 event trigger on the S3 to Glue lambda. Since this only occurs in prod/main, I've written a separate github workflow which deploys to prod/main and configures this trigger. This workflow is run whenever we push a semantically versioned tag to this repo. 