### PR TITLE
[ETL-327] Integrate RECOVER tests into CI/CD

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,75 @@
+# recover github workflows
+
+Recover ETL has four github workflows:
+
+- workflows/upload-and-deploy.yaml
+- workflows/upload-and-deploy-to-prod-main.yaml
+- workflows/codeql-analysis.yml
+- workflows/cleanup.yaml
+
+| Workflow name                     | Scenario it's run |
+| :-------------------------------- |:----------------  |
+| upload-and-deploy                 | on-push from feature branch, feature branch merged into main |
+| upload-and-deploy-to-prod-main    | whenever a new tag is created |
+| codeql-analysis                   | on-push from feature branch, feature branch merged into main
+| cleanup                           | feature branch deleted |
+
+## upload-and-deploy
+
+Here are some more detailed descriptions and troubleshooting tips for some jobs within each workflow:
+
+### upload-files
+
+Copies pilot data sets from ingestion bucket to input data bucket for use in integration test. Note that this behavior assumes that there are files in the ingestion bucket. Could add updates to make this robust and throw an error if the ingestion bucket path is empty.
+
+### nonglue-unit-tests
+
+See [testing](/tests/README.md) for more info on the background behind these tests. Here, both the `recover-dev-input-data` and `recover-dev-processed-data` buckets' synapse folders are tested for STS access every time something is pushed to the feature branch and when the feature branch is merged to main.
+
+This is like an integration test and because it depends on connection to Synapse, sometimes the connection will be stalled, broken, etc. Usually this test will only take 1 min or less. Sometimes just re-running this job will do the trick.
+
+### pytest-docker
+
+This sets up and uploads the two docker images to ECR repository.
+**Note: A ECR repo called `pytest` would need to exist in the AWS account we are pushing docker images to prior to running this GH action.**
+
+Some behavioral aspects to note - there were limitations with the matrix method in Github action jobs thus had to unmask account id to pass it as an output for `glue-unit-tests` to use. The matrix method at this time [see issue thread](https://github.com/orgs/community/discussions/17245) doesn't support dynamic job outputs and the workaround seemed more complex to implement, thus we weren't able to pass the path of the uploaded docker container directly and had to use a static output. This leads us to use `steps.login-ecr.outputs.registry` which contains account id directly so the output could be passed and the docker container could be found and used.
+
+### glue-unit-tests
+
+See [testing](/tests/README.md) for more info on the background behind these tests.
+
+For the JSON to Parquet tests sometimes there may be a scenario where a github workflow gets stopped early due to an issue/gets canceled.
+
+With the current way when the `test_json_to_parquet.py` run, sometimes the glue table, glue crawler role and other resources may have been created already for the given branch (and didn’t get deleted because the test didn’t run all the way through) and will error out when the github workflow gets triggered again because it hits the `AlreadyExistsException`. This is currently resolved manually by deleting the resource(s) that has been created in the AWS account and re-running the github jobs that failed.
+
+### sceptre-deploy-develop
+
+### integration-test-develop
+
+This builds the S3 to JSON lambda and triggers it with the pilot data so that the Recover ETL Glue Workflow will start running and processing the pilot data. **Note** that this will run with every push to the feature branch so it would be good to wait until one run of the Glue workflow finishes running as we cannot have more than 1 concurrent Glue Workflow run.
+
+Note that using `sam build` or `sam invoke` here means that the Github workflow will **NOT** throw any error even if the build or invoke fails. You will have to check the Github workflow run logs or check the Glue Workflow run to make sure the workflow was started.
+
+This integration test means that you have to wait until the glue workflow has finished to completion and review the resulting parquet datasets and compare parquet comparison results of the current run prior to merging this into `main`.
+
+### sceptre-deploy-staging
+
+Here that we are **NOT** configuring a S3 event notification configuration for our `prod/staging` space because we plan to submit data to `staging` "manually" after merging a PR into main and triggering the GitHub workflow.
+
+## upload-and-deploy-to-prod-main
+
+This runs **ONLY** when we create a new tag.
+
+### sts-access-test
+
+Here, both the (prod) `recover-input-data` and `recover-processed-data` buckets' synapse folders are tested for STS access every time a new tag is created for main.
+
+This is like an integration test and because it depends on connection to Synapse, sometimes the connection will be stalled, broken, etc. Usually this test will only take 1 min or less. Sometimes just re-running this job will do the trick.
+
+## cleanup
+
+This deletes **ONLY** the following:
+
+- **namespaced** stacks
+- cloudformation artifacts (e.g: scripts)

--- a/.github/workflows/upload-and-deploy-to-prod-main.yaml
+++ b/.github/workflows/upload-and-deploy-to-prod-main.yaml
@@ -80,3 +80,38 @@ jobs:
           FunctionName: ${{ env.NAMESPACE }}-S3EventConfig
           Payload: '{"RequestType": "Create"}'
           LogType: Tail
+
+
+  sts-access-test:
+    name: Runs STS access tests on prod synapse folders
+    runs-on: ubuntu-latest
+    needs: sceptre-deploy-main
+    environment: prod
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Setup code, pipenv, aws
+        uses: Sage-Bionetworks/action-pipenv-aws-setup@v3
+        with:
+          role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
+          role_session_name: ${{ github.event.repository.name }}-${{ github.run_id }}-nonglue-unit-tests
+          python_version: ${{ env.PYTHON_VERSION }}
+
+      - name: Test prod synapse folders for STS access with pytest
+        run: >
+          pipenv run python -m pytest tests/test_setup_external_storage.py
+          --test-bucket recover-input-data
+          --test-synapse-folder-id syn51714264
+          --namespace $NAMESPACE
+          --test-sts-permission read_only
+          -v
+
+          pipenv run python -m pytest tests/test_setup_external_storage.py
+          --test-bucket recover-processed-data
+          --test-synapse-folder-id syn51406699
+          --namespace $NAMESPACE/parquet
+          --test-sts-permission read_write
+          -v

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -8,6 +8,7 @@ on:
 env:
   NAMESPACE: main
   PYTHON_VERSION: 3.9
+  DEV_INPUT_DATA_BUCKET: recover-dev-input-data
 
 jobs:
 
@@ -46,7 +47,17 @@ jobs:
         run: echo "NAMESPACE=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
       - name: Copy files to templates bucket, use dev cloudformation bucket
-        run: python src/scripts/manage_artifacts/artifacts.py --upload --namespace $NAMESPACE --cfn_bucket ${{ vars.CFN_BUCKET }}
+        run: >
+          python src/scripts/manage_artifacts/artifacts.py
+          --upload
+          --namespace $NAMESPACE
+          --cfn_bucket ${{ vars.CFN_BUCKET }}
+
+      - name: Copies over test files from ingestion bucket
+        run: >
+          aws sync s3://recover-dev-ingestion/ s3://$DEV_INPUT_DATA_BUCKET/$NAMESPACE/
+          --exclude "owner.txt"
+          --exclude "test_upload.rtf"
 
 
   nonglue-unit-tests:
@@ -70,9 +81,13 @@ jobs:
         run: |
           pipenv run python -m pytest tests/test_s3_event_config_lambda.py -v
           pipenv run python -m pytest tests/test_s3_to_glue_lambda.py -v
+
       - name: Test synapse folders for STS access with pytest
-        run: |
-          pipenv run python -m pytest tests/test_setup_external_storage.py --test-synapse-folder-id syn51084525 --test-ssm-parameter synapse-recover-auth -v
+        run: >
+          pipenv run python -m pytest tests/test_setup_external_storage.py
+          --test-synapse-folder-id syn51084525
+          --test-ssm-parameter synapse-recover-auth
+          -v
 
 
   pytest-docker:
@@ -132,6 +147,7 @@ jobs:
       ecr-username: ${{ steps.login-ecr.outputs[steps.ecr.outputs.username-key] }}
       ecr-password: ${{ steps.login-ecr.outputs[steps.ecr.outputs.password-key] }}
 
+
   glue-unit-tests:
     name: Run Pytest unit tests for AWS glue
     needs: pytest-docker
@@ -178,13 +194,15 @@ jobs:
 
       - name: Run Pytest unit tests under AWS 4.0
         if: matrix.tag_name == 'aws_glue_4'
-        run: su - glue_user --command "cd $GITHUB_WORKSPACE && python3 -m pytest tests/test_json_to_parquet.py --namespace $NAMESPACE -v"
+        run: >
+          su - glue_user --command "cd $GITHUB_WORKSPACE &&
+          python3 -m pytest tests/test_json_to_parquet.py --namespace $NAMESPACE -v"
 
 
   sceptre-deploy-develop:
     name: Deploys branch using sceptre
     runs-on: ubuntu-latest
-    needs: [pre-commit, upload-files, nonglue-unit-tests, pytest-docker, glue-unit-tests]
+    needs: [upload-files, nonglue-unit-tests, glue-unit-tests]
     environment: develop
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
@@ -220,10 +238,51 @@ jobs:
           Payload: '{"RequestType": "Create"}'
           LogType: Tail
 
+
+  integration-test-develop:
+    name: Triggers ETL workflow with S3 test files
+    runs-on: ubuntu-latest
+    needs: sceptre-deploy-develop
+    environment: develop
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Setup code, pipenv, aws
+        uses: Sage-Bionetworks/action-pipenv-aws-setup@v3
+        with:
+          role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
+          role_session_name: integration-test-${{ github.run_id }}
+          python_version: ${{ env.PYTHON_VERSION }}
+
+      - name: Set namespace for non-default branch or for tag
+        if: github.ref_name != 'main'
+        run: echo "NAMESPACE=$GITHUB_REF_NAME" >> $GITHUB_ENV
+
+      - name: generate test events
+        run: >
+          pipenv run python src/lambda_function/s3_to_glue/events/generate_test_event.py
+          --input-bucket $DEV_INPUT_DATA_BUCKET
+          --input-key-prefix $NAMESPACE
+
+      - name: Setup sam
+        uses: aws-actions/setup-sam@v2
+
+      - name: sam build lambda
+        run: >
+          sam build
+          -s src/lambda_function/s3_to_glue/
+          -t src/lambda_function/s3_to_glue/template.yaml
+
+      - name: Invoke Lambda
+        run: sam local invoke -e records.json
+
+
   sceptre-deploy-staging:
     name: Deploys to staging of prod using sceptre
     runs-on: ubuntu-latest
-    needs: [pre-commit, upload-files, nonglue-unit-tests, pytest-docker, glue-unit-tests, sceptre-deploy-develop]
+    needs: integration-test-develop
     if: github.ref_name == 'main'
     environment: prod
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -102,19 +102,17 @@ jobs:
           echo "username-key=$usernameKey" >> $GITHUB_OUTPUT
           passwordKey=docker_password_$(echo ${{ steps.login-ecr.outputs.registry }} | tr '.-' _)
           echo "password-key=$passwordKey" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
       - name: Build and push to ECR
         id: docker-build-push
-        uses: docker/build-push-action@v4
-        env:
-          DOCKER_IMAGE: ${{ steps.login-ecr.outputs.registry }}/pytest:${{ github.ref_name }}
+        uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ${{ env.DOCKER_IMAGE }}
+          tags: ${{ steps.login-ecr.outputs.registry }}/pytest:${{ github.ref_name }}
           file: tests/Dockerfile.aws_glue_3
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -97,6 +97,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
           aws-region: "us-east-1"
+          mask-aws-account-id: "no"
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -140,8 +141,7 @@ jobs:
     strategy:
       matrix:
           tag_name:
-            - aws_glue_3
-            - aws_glue_4
+            ["aws_glue_3", "aws_glue_4"]
     container:
       image: ${{ needs.pytest-docker.outputs.ecr-registry }}/pytest:${{ github.ref_name }}_${{ matrix.tag_name }}
       credentials:

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -88,8 +88,8 @@ jobs:
       - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
-          role_session_name: ${{ github.event.repository.name }}-${{ github.run_id }}-nonglue-unit-tests
+          role-to-assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
+          role-session-name: ${{ github.event.repository.name }}-${{ github.run_id }}-nonglue-unit-tests
           aws-region: "us-east-1"
           role-duration-seconds: 1200
       - name: Login to Amazon ECR

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -68,11 +68,11 @@ jobs:
 
       - name: Test lambda scripts with pytest
         run: |
-          python3 -m pytest tests/test_s3_event_config_lambda.py
-          python3 -m pytest tests/test_s3_to_glue_lambda.py
+          pipenv run python -m pytest tests/test_s3_event_config_lambda.py
+          pipenv run python -m pytest tests/test_s3_to_glue_lambda.py
       - name: Test synapse folders for STS access with pytest
         run: |
-          python3 -m pytest tests/test_setup_external_storage.py --test-synapse-folder-id syn51084525 --test-ssm-parameter synapse-recover-auth
+          pipenv run python -m pytest tests/test_setup_external_storage.py --test-synapse-folder-id syn51084525 --test-ssm-parameter synapse-recover-auth
 
   sceptre-deploy-develop:
     name: Deploys branch using sceptre

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -52,7 +52,7 @@ jobs:
   nonglue-unit-tests:
     name: Runs unit tests that are not dependent on aws-glue package resources
     runs-on: ubuntu-latest
-    needs: [pre-commit, upload-files]
+    needs: pre-commit
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write
@@ -77,7 +77,7 @@ jobs:
 
   pytest-docker:
     name: Build and push testing docker images to ECR
-    needs: upload-files
+    needs: pre-commit
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
@@ -86,7 +86,7 @@ jobs:
     environment: develop
     steps:
       - name: Assume AWS role
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
           role_session_name: ${{ github.event.repository.name }}-${{ github.run_id }}-nonglue-unit-tests
@@ -121,7 +121,7 @@ jobs:
   sceptre-deploy-develop:
     name: Deploys branch using sceptre
     runs-on: ubuntu-latest
-    needs: [pre-commit, upload-files, nonglue-unit-tests]
+    needs: [pre-commit, upload-files, nonglue-unit-tests, pytest-docker]
     environment: develop
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
@@ -160,7 +160,7 @@ jobs:
   sceptre-deploy-staging:
     name: Deploys to staging of prod using sceptre
     runs-on: ubuntu-latest
-    needs: [pre-commit, upload-files, nonglue-unit-tests, sceptre-deploy-develop]
+    needs: [pre-commit, upload-files, nonglue-unit-tests, pytest-docker, sceptre-deploy-develop]
     if: github.ref_name == 'main'
     environment: prod
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -83,7 +83,6 @@ jobs:
           pipenv run python -m pytest tests/test_s3_to_glue_lambda.py -v
 
       - name: Test dev synapse folders for STS access with pytest
-        if: github.ref_name == 'main'
         run: >
           pipenv run python -m pytest tests/test_setup_external_storage.py
           --test-bucket $DEV_INPUT_BUCKET

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -64,11 +64,11 @@ jobs:
 
       - name: Test lambda scripts with pytest
         run: |
-          pytest tests/test_s3_event_config_lambda.py
-          pytest tests/test_s3_to_glue_lambda.py
+          python3 -m pytest tests/test_s3_event_config_lambda.py
+          python3 -m pytest tests/test_s3_to_glue_lambda.py
       - name: Test synapse folders for STS access with pytest
         run: |
-          pytest tests/test_setup_external_storage.py --test-synapse-folder-id syn51084525 --test-ssm-parameter synapse-recover-auth
+          python3 -m pytest tests/test_setup_external_storage.py --test-synapse-folder-id syn51084525 --test-ssm-parameter synapse-recover-auth
 
   sceptre-deploy-develop:
     name: Deploys branch using sceptre

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -85,9 +85,6 @@ jobs:
       contents: read
     environment: develop
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-
       - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -113,9 +110,11 @@ jobs:
       - name: Build and push to ECR
         id: docker-build-push
         uses: docker/build-push-action@v4
+        env:
+          DOCKER_IMAGE: ${{ steps.login-ecr.outputs.registry }}/pytest:${{ github.ref_name }}
         with:
           push: true
-          tags: ${{ steps.login-ecr.outputs.registry }}/pytest:${{ github.ref_name }}
+          tags: ${{ env.DOCKER_IMAGE }}
           file: tests/Dockerfile.aws_glue_3
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -100,8 +100,6 @@ jobs:
 
 
   pytest-docker:
-    # A ECR repo called pytest would need to exist in the AWS account
-    # we are pushing docker images to prior to this
     name: Build and push testing docker images to the pytest ECR repository.
     needs: pre-commit
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -90,6 +90,8 @@ jobs:
         with:
           role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
           role_session_name: ${{ github.event.repository.name }}-${{ github.run_id }}-nonglue-unit-tests
+          aws-region: "us-east-1"
+          role-duration-seconds: 1200
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -278,7 +278,7 @@ jobs:
       - name: Invoke Lambda
         run: |
           cd src/lambda_function/s3_to_glue/
-          sam local invoke -e events/records.json --parameter-overrides 'PrimaryWorkflowName=$NAMESPACE-PrimaryWorkflow'
+          sam local invoke -e events/records.json --parameter-overrides "PrimaryWorkflowName=$NAMESPACE-PrimaryWorkflow"
 
 
   sceptre-deploy-staging:

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -50,7 +50,7 @@ jobs:
 
 
   nonglue-unit-tests:
-    name: Runs unit tests that are dependent on aws-glue package resources
+    name: Runs unit tests that are not dependent on aws-glue package resources
     runs-on: ubuntu-latest
     needs: [pre-commit, upload-files]
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
@@ -73,6 +73,49 @@ jobs:
       - name: Test synapse folders for STS access with pytest
         run: |
           pipenv run python -m pytest tests/test_setup_external_storage.py --test-synapse-folder-id syn51084525 --test-ssm-parameter synapse-recover-auth -v
+
+
+  pytest-docker:
+    name: Build and push testing docker images to ECR
+    needs: upload-files
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    environment: develop
+    steps:
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
+          role_session_name: ${{ github.event.repository.name }}-${{ github.run_id }}-nonglue-unit-tests
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Get ECR secret names
+        id: ecr
+        run: |
+          usernameKey=docker_username_$(echo ${{ steps.login-ecr.outputs.registry }} | tr '.-' _)
+          echo "username-key=$usernameKey" >> $GITHUB_OUTPUT
+          passwordKey=docker_password_$(echo ${{ steps.login-ecr.outputs.registry }} | tr '.-' _)
+          echo "password-key=$passwordKey" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build and push to ECR
+        id: docker-build-push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ${{ steps.login-ecr.outputs.registry }}/pytest:${{ github.ref_name }}
+          file: tests/Dockerfile.aws_glue_3
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+    outputs:
+      docker-metadata: ${{ steps.docker-build-push.outputs.metadata }}
+      ecr-username: ${{ steps.login-ecr.outputs[steps.ecr.outputs.username-key] }}
+      ecr-password: ${{ steps.login-ecr.outputs[steps.ecr.outputs.password-key] }}
 
 
   sceptre-deploy-develop:

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -53,6 +53,10 @@ jobs:
     name: Runs unit tests that are dependent on aws-glue package resources
     runs-on: ubuntu-latest
     needs: [pre-commit, upload-files]
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
     environment: develop
     steps:
       - name: Setup code, pipenv, aws

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -68,11 +68,12 @@ jobs:
 
       - name: Test lambda scripts with pytest
         run: |
-          pipenv run python -m pytest tests/test_s3_event_config_lambda.py
-          pipenv run python -m pytest tests/test_s3_to_glue_lambda.py
+          pipenv run python -m pytest tests/test_s3_event_config_lambda.py -v
+          pipenv run python -m pytest tests/test_s3_to_glue_lambda.py -v
       - name: Test synapse folders for STS access with pytest
         run: |
-          pipenv run python -m pytest tests/test_setup_external_storage.py --test-synapse-folder-id syn51084525 --test-ssm-parameter synapse-recover-auth
+          pipenv run python -m pytest tests/test_setup_external_storage.py --test-synapse-folder-id syn51084525 --test-ssm-parameter synapse-recover-auth -v
+
 
   sceptre-deploy-develop:
     name: Deploys branch using sceptre

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -56,9 +56,8 @@ jobs:
 
       - name: Copies over test files from ingestion bucket
         run: >
-          aws s3 sync s3://recover-dev-ingestion/ s3://$DEV_INPUT_BUCKET/$NAMESPACE/
+          aws s3 sync s3://recover-dev-ingestion/pilot-data/ s3://$DEV_INPUT_BUCKET/$NAMESPACE/
           --exclude "owner.txt"
-          --exclude "test_upload.rtf"
 
 
   nonglue-unit-tests:

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -88,14 +88,14 @@ jobs:
           --test-bucket $DEV_INPUT_BUCKET
           --test-synapse-folder-id syn51758510
           --namespace $NAMESPACE
-          --test_sts_permission read_only
+          --test-sts-permission read_only
           -v
 
           pipenv run python -m pytest tests/test_setup_external_storage.py
           --test-bucket $DEV_PROCESSED_BUCKET
           --test-synapse-folder-id syn51084525
           --namespace $NAMESPACE/parquet
-          --test_sts_permission read_write
+          --test-sts-permission read_write
           -v
 
 

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -276,7 +276,9 @@ jobs:
           -t src/lambda_function/s3_to_glue/template.yaml
 
       - name: Invoke Lambda
-        run: sam local invoke -e records.json
+        run: |
+          cd src/lambda_function/s3_to_glue/
+          sam local invoke -e events/records.json
 
 
   sceptre-deploy-staging:

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -275,6 +275,7 @@ jobs:
           pipenv run python src/lambda_function/s3_to_glue/events/generate_test_event.py
           --input-bucket $DEV_INPUT_BUCKET
           --input-key-prefix $NAMESPACE
+          --output-directory ./src/lambda_function/s3_to_glue/events/
 
       - name: Setup sam
         uses: aws-actions/setup-sam@v2

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -49,10 +49,29 @@ jobs:
         run: python src/scripts/manage_artifacts/artifacts.py --upload --namespace $NAMESPACE --cfn_bucket ${{ vars.CFN_BUCKET }}
 
 
+  nonglue-unit-tests:
+    name: Runs unit tests that are dependent on aws-glue package resources
+    runs-on: ubuntu-latest
+    needs: [pre-commit, upload-files]
+    environment: develop
+    steps:
+      - name: Setup code, pipenv, aws
+        uses: Sage-Bionetworks/action-pipenv-aws-setup@v3
+        with:
+          role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
+          role_session_name: ${{ github.event.repository.name }}-${{ github.run_id }}-nonglue-unit-tests
+          python_version: ${{ env.PYTHON_VERSION }}
+
+      - name: Test with pytest
+        run: |
+          pytest tests/test_s3_event_config_lambda.py
+          pytest tests/test_s3_to_glue_lambda.py
+          pytest tests/test_setup_external_storage.py --test-synapse-folder-id syn51084525 --test-ssm-parameter synapse-recover-auth
+
   sceptre-deploy-develop:
     name: Deploys branch using sceptre
     runs-on: ubuntu-latest
-    needs: [pre-commit, upload-files]
+    needs: [pre-commit, upload-files, nonglue-unit-tests]
     environment: develop
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
@@ -91,7 +110,7 @@ jobs:
   sceptre-deploy-staging:
     name: Deploys to staging of prod using sceptre
     runs-on: ubuntu-latest
-    needs: [pre-commit, upload-files, sceptre-deploy-develop]
+    needs: [pre-commit, upload-files, nonglue-unit-tests, sceptre-deploy-develop]
     if: github.ref_name == 'main'
     environment: prod
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -76,7 +76,9 @@ jobs:
 
 
   pytest-docker:
-    name: Build and push testing docker images to ECR
+    # A ECR repo called pytest would need to exist in the AWS account
+    # we are pushing docker images to prior to this
+    name: Build and push testing docker images to the pytest ECR repository.
     needs: pre-commit
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
@@ -97,6 +99,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
           aws-region: "us-east-1"
+          # unmasking of the AWS account ID allows the acct id to pass through outputs
           mask-aws-account-id: "no"
 
       - name: Login to Amazon ECR

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -278,7 +278,7 @@ jobs:
       - name: Invoke Lambda
         run: |
           cd src/lambda_function/s3_to_glue/
-          sam local invoke -e events/records.json
+          sam local invoke -e events/records.json --parameter-overrides 'PrimaryWorkflowName=$NAMESPACE-PrimaryWorkflow'
 
 
   sceptre-deploy-staging:

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -8,7 +8,8 @@ on:
 env:
   NAMESPACE: main
   PYTHON_VERSION: 3.9
-  DEV_INPUT_DATA_BUCKET: recover-dev-input-data
+  DEV_INPUT_BUCKET: recover-dev-input-data
+  DEV_PROCESSED_BUCKET: recover-dev-processed-data
 
 jobs:
 
@@ -55,7 +56,7 @@ jobs:
 
       - name: Copies over test files from ingestion bucket
         run: >
-          aws s3 sync s3://recover-dev-ingestion/ s3://$DEV_INPUT_DATA_BUCKET/$NAMESPACE/
+          aws s3 sync s3://recover-dev-ingestion/ s3://$DEV_INPUT_BUCKET/$NAMESPACE/
           --exclude "owner.txt"
           --exclude "test_upload.rtf"
 
@@ -82,11 +83,21 @@ jobs:
           pipenv run python -m pytest tests/test_s3_event_config_lambda.py -v
           pipenv run python -m pytest tests/test_s3_to_glue_lambda.py -v
 
-      - name: Test synapse folders for STS access with pytest
+      - name: Test dev synapse folders for STS access with pytest
+        if: github.ref_name == 'main'
         run: >
           pipenv run python -m pytest tests/test_setup_external_storage.py
+          --test-bucket $DEV_INPUT_BUCKET
+          --test-synapse-folder-id syn51758510
+          --namespace $NAMESPACE
+          --test_sts_permission read_only
+          -v
+
+          pipenv run python -m pytest tests/test_setup_external_storage.py
+          --test-bucket $DEV_PROCESSED_BUCKET
           --test-synapse-folder-id syn51084525
-          --test-ssm-parameter synapse-recover-auth
+          --namespace $NAMESPACE/parquet
+          --test_sts_permission read_write
           -v
 
 
@@ -263,7 +274,7 @@ jobs:
       - name: generate test events
         run: >
           pipenv run python src/lambda_function/s3_to_glue/events/generate_test_event.py
-          --input-bucket $DEV_INPUT_DATA_BUCKET
+          --input-bucket $DEV_INPUT_BUCKET
           --input-key-prefix $NAMESPACE
 
       - name: Setup sam

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -62,10 +62,12 @@ jobs:
           role_session_name: ${{ github.event.repository.name }}-${{ github.run_id }}-nonglue-unit-tests
           python_version: ${{ env.PYTHON_VERSION }}
 
-      - name: Test with pytest
+      - name: Test lambda scripts with pytest
         run: |
           pytest tests/test_s3_event_config_lambda.py
           pytest tests/test_s3_to_glue_lambda.py
+      - name: Test synapse folders for STS access with pytest
+        run: |
           pytest tests/test_setup_external_storage.py --test-synapse-folder-id syn51084525 --test-ssm-parameter synapse-recover-auth
 
   sceptre-deploy-develop:

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -83,6 +83,13 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    strategy:
+      matrix:
+        include:
+          - tag_name: aws_glue_3
+            dockerfile: tests/Dockerfile.aws_glue_3
+          - tag_name: aws_glue_4
+            dockerfile: tests/Dockerfile.aws_glue_4
     environment: develop
     steps:
       - name: Assume AWS role
@@ -102,30 +109,79 @@ jobs:
           echo "username-key=$usernameKey" >> $GITHUB_OUTPUT
           passwordKey=docker_password_$(echo ${{ steps.login-ecr.outputs.registry }} | tr '.-' _)
           echo "password-key=$passwordKey" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
       - name: Build and push to ECR
         id: docker-build-push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           push: true
-          tags: ${{ steps.login-ecr.outputs.registry }}/pytest:${{ github.ref_name }}
-          file: tests/Dockerfile.aws_glue_3
+          tags: ${{ steps.login-ecr.outputs.registry }}/pytest:${{ github.ref_name }}_${{ matrix.tag_name }}
+          file: ${{ matrix.dockerfile }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
     outputs:
-      docker-metadata: ${{ steps.docker-build-push.outputs.metadata }}
+      ecr-registry: ${{ steps.login-ecr.outputs.registry }}
       ecr-username: ${{ steps.login-ecr.outputs[steps.ecr.outputs.username-key] }}
       ecr-password: ${{ steps.login-ecr.outputs[steps.ecr.outputs.password-key] }}
+
+  glue-unit-tests:
+    name: Run Pytest unit tests for AWS glue
+    needs: pytest-docker
+    environment: develop
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+          tag_name:
+            - aws_glue_3
+            - aws_glue_4
+    container:
+      image: ${{ needs.pytest-docker.outputs.ecr-registry }}/pytest:${{ github.ref_name }}_${{ matrix.tag_name }}
+      credentials:
+        username: ${{ needs.pytest-docker.outputs.ecr-username }}
+        password: ${{ needs.pytest-docker.outputs.ecr-password }}
+      env:
+        DISABLE_SSL: true
+      options: "--user root"
+    steps:
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
+          aws-region: "us-east-1"
+      - uses: actions/checkout@v3
+      - run: chown -R glue_user $GITHUB_WORKSPACE
+      - run: su - glue_user --command "aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID"
+      - run: su - glue_user --command "aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY"
+      - run: su - glue_user --command "aws configure set aws_session_token $AWS_SESSION_TOKEN"
+      - run: su - glue_user --command "aws configure set region $AWS_REGION"
+
+      - name: Set namespace for non-default branch or for tag
+        if: github.ref_name != 'main'
+        run: echo "NAMESPACE=$GITHUB_REF_NAME" >> $GITHUB_ENV
+
+      - name: Run Pytest unit tests under AWS 3.0
+        if: matrix.tag_name == 'aws_glue_3'
+        run: |
+          su - glue_user --command "cd $GITHUB_WORKSPACE && python3 -m pytest tests/test_s3_to_json.py -v"
+          su - glue_user --command "cd $GITHUB_WORKSPACE && python3 -m pytest tests/test_compare_parquet_datasets.py -v"
+
+      - name: Run Pytest unit tests under AWS 4.0
+        if: matrix.tag_name == 'aws_glue_4'
+        run: su - glue_user --command "cd $GITHUB_WORKSPACE && python3 -m pytest tests/test_json_to_parquet.py --namespace $NAMESPACE -v"
 
 
   sceptre-deploy-develop:
     name: Deploys branch using sceptre
     runs-on: ubuntu-latest
-    needs: [pre-commit, upload-files, nonglue-unit-tests, pytest-docker]
+    needs: [pre-commit, upload-files, nonglue-unit-tests, pytest-docker, glue-unit-tests]
     environment: develop
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
@@ -164,7 +220,7 @@ jobs:
   sceptre-deploy-staging:
     name: Deploys to staging of prod using sceptre
     runs-on: ubuntu-latest
-    needs: [pre-commit, upload-files, nonglue-unit-tests, pytest-docker, sceptre-deploy-develop]
+    needs: [pre-commit, upload-files, nonglue-unit-tests, pytest-docker, glue-unit-tests, sceptre-deploy-develop]
     if: github.ref_name == 'main'
     environment: prod
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -85,16 +85,19 @@ jobs:
       contents: read
     environment: develop
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
       - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
-          role-session-name: ${{ github.event.repository.name }}-${{ github.run_id }}-nonglue-unit-tests
           aws-region: "us-east-1"
-          role-duration-seconds: 1200
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
+
       - name: Get ECR secret names
         id: ecr
         run: |
@@ -103,8 +106,10 @@ jobs:
           passwordKey=docker_password_$(echo ${{ steps.login-ecr.outputs.registry }} | tr '.-' _)
           echo "password-key=$passwordKey" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
       - name: Build and push to ECR
         id: docker-build-push
         uses: docker/build-push-action@v4

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Copies over test files from ingestion bucket
         run: >
-          aws sync s3://recover-dev-ingestion/ s3://$DEV_INPUT_DATA_BUCKET/$NAMESPACE/
+          aws s3 sync s3://recover-dev-ingestion/ s3://$DEV_INPUT_DATA_BUCKET/$NAMESPACE/
           --exclude "owner.txt"
           --exclude "test_upload.rtf"
 

--- a/src/lambda_function/s3_to_glue/events/generate_test_event.py
+++ b/src/lambda_function/s3_to_glue/events/generate_test_event.py
@@ -12,12 +12,13 @@ See https://github.com/Sage-Bionetworks/recover/tree/main/src/lambda_function
 for detailed information how to use this event with the Lambda.
 """
 
+import os
 import argparse
 import json
 import boto3
 
-SINGLE_RECORD_OUTFILE = './src/lambda_function/s3_to_glue/events/single-record.json'
-MULTI_RECORD_OUTFILE = './src/lambda_function/s3_to_glue/events/records.json'
+SINGLE_RECORD_OUTFILE = 'single-record.json'
+MULTI_RECORD_OUTFILE = 'records.json'
 
 
 def read_args() -> argparse.Namespace:
@@ -40,6 +41,12 @@ def read_args() -> argparse.Namespace:
             help=("Takes precedence over `--input-key`. If you want "
                   "to generate a single event containing all data under a specific "
                   "S3 key prefix, specify that here.")
+    )
+    parser.add_argument(
+            "--output-directory",
+            default = "./",
+            help=("Specifies the directory that the S3 notification json gets saved to. "
+                  "Defaults to current directory that the script is running from. ")
     )
     args = parser.parse_args()
     return args
@@ -137,11 +144,11 @@ def main() -> None:
     )
 
     if args.input_key_prefix is not None:
-        with open(MULTI_RECORD_OUTFILE, "w") as outfile:
+        with open(os.path.join(args.output_directory, MULTI_RECORD_OUTFILE), "w") as outfile:
             json.dump(s3_event, outfile)
             print(f"Event with multiple records written to {outfile.name}.")
     else:
-        with open(SINGLE_RECORD_OUTFILE, "w") as outfile:
+        with open(os.path.join(args.output_directory, SINGLE_RECORD_OUTFILE), "w") as outfile:
             json.dump(s3_event, outfile)
             print(f"Event with single record written to {outfile.name}.")
     print("Done.")

--- a/src/lambda_function/s3_to_glue/events/generate_test_event.py
+++ b/src/lambda_function/s3_to_glue/events/generate_test_event.py
@@ -16,8 +16,8 @@ import argparse
 import json
 import boto3
 
-SINGLE_RECORD_OUTFILE = 'single-record.json'
-MULTI_RECORD_OUTFILE = 'records.json'
+SINGLE_RECORD_OUTFILE = './src/lambda_function/s3_to_glue/events/single-record.json'
+MULTI_RECORD_OUTFILE = './src/lambda_function/s3_to_glue/events/records.json'
 
 
 def read_args() -> argparse.Namespace:

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,0 @@
-FROM amazon/aws-glue-libs:glue_libs_4.0.0_image_01
-
-RUN pip3 install moto~=4.1 synapseclient~=2.7 pyarrow~=11.0 datacompy~=0.8 pytest-datadir
-ENTRYPOINT ["bash", "-l"]

--- a/tests/Dockerfile.aws_glue_3
+++ b/tests/Dockerfile.aws_glue_3
@@ -1,0 +1,4 @@
+FROM amazon/aws-glue-libs:glue_libs_3.0.0_image_01
+
+RUN pip3 install moto~=4.1 datacompy~=0.8 pytest-datadir
+ENTRYPOINT ["bash", "-l"]

--- a/tests/Dockerfile.aws_glue_4
+++ b/tests/Dockerfile.aws_glue_4
@@ -1,0 +1,4 @@
+FROM amazon/aws-glue-libs:glue_libs_4.0.0_image_01
+
+RUN pip3 install moto~=4.1 pytest-datadir
+ENTRYPOINT ["bash", "-l"]

--- a/tests/README.md
+++ b/tests/README.md
@@ -59,7 +59,7 @@ You can find your test related resources here (for reviewing/troubleshooting):
 `s3://<recover_artifacts_bucket_name>/<namespace>/tests/test_json_to_parquet`
 
 ```shell script
-python3 -m pytest <path_to_your_specific_script> -namespace <name_of_namespace_to_use> -v
+python3 -m pytest <path_to_your_specific_script> --namespace <name_of_namespace_to_use> -v
 ```
 
 ##### Running tests for everything else

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,12 +4,21 @@ Tests are defined in the `tests` folder in this project.
 #### Running tests using Docker
 All tests can be run inside a Docker container which includes all the necessary
 Glue/Spark dependencies and simulates the environment which the Glue jobs
-will be run in. A Dockerfile is included in the `tests` directory
+will be run in. Dockerfiles for AWS versions 3.0 and 4.0 are included in the `tests` directory.
 
 To run tests locally, first configure your AWS credentials, then launch and attach
-to the docker container (see following commands)
+to the relevant docker container (see following commands)
 
-Run the following commands to run tests for the s3_to_json script (in develop).
+These scripts needs to be run inside a Docker container:
+
+- Under AWS 3.0 (Dockerfile.aws_glue_3)
+  - test_compare_parquet_datasets.py
+  - test_s3_to_json.py
+
+- Under AWS 4.0 (Dockerfile.aws_glue_4)
+  - test_json_to_parquet.py (Note that these tests deploys test resources to aws and will take several min to run)
+
+Run the following commands to run tests for:
 
 1. Navigate to the directory with the Dockerfile
 
@@ -17,13 +26,13 @@ Run the following commands to run tests for the s3_to_json script (in develop).
 cd tests
 ```
 
-2. Build the docker image from the Dockerfile
+2. Build the docker image from the Dockerfile relevant to your tests
 
 ```shell script
-docker build -t <some_name_for_container> .
+docker build -f <name_of_dockerfile> -t <some_name_for_container> .
 ```
 
-3. Run the newly built image:
+3. Run the newly built image. You can pick port numbers of your choice:
 
 ```shell script
 docker run --rm -it \
@@ -41,8 +50,22 @@ cd <repo name>
 5. Finally run the following (now that you are inside the running container)
 to execute the tests:
 
+##### Running tests for json to parquet
+
+You will need to specify a namespace variable when running the json to parquet tests so that
+the AWS resources are created and run under this namespace.
+You can find your test related resources here (for reviewing/troubleshooting):
+
+`s3://<recover_artifacts_bucket_name>/<namespace>/tests/test_json_to_parquet`
+
 ```shell script
-python3 -m pytest
+python3 -m pytest <path_to_your_specific_script> -namespace <name_of_namespace_to_use> -v
+```
+
+##### Running tests for everything else
+
+```shell script
+python3 -m pytest <path_to_your_specific_script> -v
 ```
 
 #### Running tests using pipenv
@@ -50,8 +73,8 @@ Use [pipenv](https://pipenv.pypa.io/en/latest/index.html) to install the
 [pytest](https://docs.pytest.org/en/latest/) and run tests locally outside of
 a Docker image.
 
-Here are the tests you can run locally using a pipenv. You'll run into an error with
-pytest with other tests because they have to be run in a Dockerfile:
+Here are the tests you can run locally using `pipenv`. You'll run into an error with
+pytest with other tests because they have to be run in a Dockerfile with the AWS glue environment:
 
 - test_s3_to_glue_lambda.py
 - test_s3_event_config_lambda.py

--- a/tests/test_compare_parquet_datasets.py
+++ b/tests/test_compare_parquet_datasets.py
@@ -298,7 +298,7 @@ def test_that_compare_row_diffs_returns_df_if_columns_are_not_diff(
     main_rows = compare_parquet.compare_row_diffs(compare, namespace="main")
     assert staging_rows.empty
     assert_frame_equal(
-        main_rows.reset_index(drop=True).sort_values(by='LogId'),
+        main_rows.sort_values(by='LogId').reset_index(drop=True),
         pd.DataFrame(
             {
                 "LogId": [
@@ -316,7 +316,7 @@ def test_that_compare_row_diffs_returns_df_if_columns_are_not_diff(
                 "ActiveDuration": ["2256000", "2208000"],
                 "Calories": ["473", "478"],
             }
-        ).reset_index(drop=True).sort_values(by='LogId'),
+        ).sort_values(by='LogId').reset_index(drop=True),
     )
 
 

--- a/tests/test_compare_parquet_datasets.py
+++ b/tests/test_compare_parquet_datasets.py
@@ -298,7 +298,7 @@ def test_that_compare_row_diffs_returns_df_if_columns_are_not_diff(
     main_rows = compare_parquet.compare_row_diffs(compare, namespace="main")
     assert staging_rows.empty
     assert_frame_equal(
-        main_rows.reset_index(drop=True),
+        main_rows.reset_index(drop=True).sort_values(by='LogId'),
         pd.DataFrame(
             {
                 "LogId": [
@@ -316,7 +316,7 @@ def test_that_compare_row_diffs_returns_df_if_columns_are_not_diff(
                 "ActiveDuration": ["2256000", "2208000"],
                 "Calories": ["473", "478"],
             }
-        ).reset_index(drop=True),
+        ).reset_index(drop=True).sort_values(by='LogId'),
     )
 
 


### PR DESCRIPTION
**Purpose:** This integrates all of our RECOVER tests into our github workflow `upload-and-deploy`. This composes of a some jobs:

`nonglue-unit-tests`:
- One job runs the non-glue tests under Python 3.9

`pytest-docker`:
- One job creates and uploads the dockerfile for AWS glue 3.0
- One job creates and uploads the dockerfile for AWS glue 4.0

`glue-unit-tests`:
- One job runs the tests under AWS glue 3.0
- One job runs the tests under AWS glue 4.0


Some outstanding questions are: 

- [x] - In order to use the `matrix` method for creating and launching the jobs for the two Dockerfiles (because I have to pass the account ID as part of the job output), I had to unmask the AWS account ID (it would be hidden prior), is that alright?
- [x] - It doesn't appear that we have synapse folders for pre-ETL or post-ETL for `dev`, do we plan to?
Created a temporary test dev folder for these: `syn51079325`
- [x] - We should have an integration test (like in BD) that triggers the S3 to JSON lambda with the pilot datasets to run the rest of the ETL for a `feature branch` so that `compare_parquet_datasets` can eventually run on our development pipeline. But if that is successful, and we merge the `feature branch` into `develop/main`, we should have a process after stack deployment to clear the main S3 bucket namespace on `develop` and trigger the S3 to JSON lambda to run the ETL on `develop/main`?
Yes, this process works. Json to parquet already has a process in place to automatically archive old datasets and clear the workspace.

Depends on #60 