### PR TITLE
[ETL-483] Fix testing of bucket access via STS token credentials

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -77,7 +77,6 @@ access has been set for a given synapse folder (in develop).
 python3 -m pytest tests/test_setup_external_storage.py
 --test-bucket <put_bucket_name_here>
 --test-synapse-folder-id <put_synapse_folder_id_here>
---test-ssm-parameter <put_ssm_parameter_here_or_leave_blank>
 --namespace <put_namespace_here>
 --test_sts_permission <put_the_type_of_permission_to_test_here>
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -78,5 +78,9 @@ This test takes in two command line arguments:
 - test-ssm-parameter - ssm parameter to get AWS credentials for otherwise leave blank and it will pull credentials from the environment
 
 ```shell script
-python3 -m pytest tests/test_setup_external_storage.py --test-synapse-folder-id <put_synapse_folder_id_here> --test-ssm-parameter <put_ssm_parameter_here_or_leave_blank>
+python3 -m pytest tests/test_setup_external_storage.py
+--test-synapse-folder-id <put_synapse_folder_id_here>
+--test-ssm-parameter <put_ssm_parameter_here_or_leave_blank>
+--namespace <put_namespace_here>
+--test_sts_permission <put_the_type_of_permission_to_test_here>
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -72,13 +72,10 @@ python3 -m pytest tests/test_s3_event_config_lambda.py -v
 Run the following command from the repo root to run the integration test for the setup external storage script to check that the STS
 access has been set for a given synapse folder (in develop).
 
-This test takes in two command line arguments:
-
-- test-synapse-folder-id - synapse id of the folder to check STS access for
-- test-ssm-parameter - ssm parameter to get AWS credentials for otherwise leave blank and it will pull credentials from the environment
 
 ```shell script
 python3 -m pytest tests/test_setup_external_storage.py
+--test-bucket <put_bucket_name_here>
 --test-synapse-folder-id <put_synapse_folder_id_here>
 --test-ssm-parameter <put_ssm_parameter_here_or_leave_blank>
 --namespace <put_namespace_here>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -265,12 +265,6 @@ def pytest_addoption(parser):
         default=None,
         help="ID of the synapse folder to check STS access. Required.",
     )
-    parser.addoption(
-        "--test-ssm-parameter",
-        action="store",
-        default=None,
-        help="The SSM parameter to use to check STS access. Optional",
-    )
     parser.addoption("--namespace", default=None, help="The namespace to test.")
     parser.addoption(
         "--test-sts-permission",
@@ -299,3 +293,8 @@ def namespace(pytestconfig):
 @pytest.fixture(scope="session")
 def artifact_bucket():
     yield "recover-dev-cloudformation"
+
+
+@pytest.fixture(scope="session")
+def ssm_parameter():
+    yield "synapse-recover-auth"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -271,21 +271,30 @@ def pytest_addoption(parser):
         default=None,
         help="The SSM parameter to use to check STS access. Optional",
     )
-    parser.addoption(
-        "--namespace",
-        default=None,
-        help="The namespace to test."
-    )
+    parser.addoption("--namespace", default=None, help="The namespace to test.")
     parser.addoption(
         "--test-sts-permission",
-        default=None,
-        choices= ["read_only", "read_write"],
-        help="The permission type to use for the STS token credentials. Required."
+        default="read_only",
+        choices=["read_only", "read_write"],
+        help="The permission type to use for the STS token credentials. Required.",
     )
+    parser.addoption(
+        "--test-bucket",
+        default=None,
+        choices=[
+            "recover-input-data",
+            "recover-processed-data",
+            "recover-dev-input-data",
+            "recover-dev-processed-data",
+        ],
+        help="The bucket to test access with the STS token credentials. Required.",
+    )
+
 
 @pytest.fixture(scope="session")
 def namespace(pytestconfig):
     yield pytestconfig.getoption("namespace")
+
 
 @pytest.fixture(scope="session")
 def artifact_bucket():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -276,6 +276,12 @@ def pytest_addoption(parser):
         default=None,
         help="The namespace to test."
     )
+    parser.addoption(
+        "--test-sts-permission",
+        default=None,
+        choices= ["read_only", "read_write"],
+        help="The permission type to use for the STS token credentials. Required."
+    )
 
 @pytest.fixture(scope="session")
 def namespace(pytestconfig):

--- a/tests/test_setup_external_storage.py
+++ b/tests/test_setup_external_storage.py
@@ -27,3 +27,9 @@ def test_setup_external_storage_success(test_synapse_folder_id, test_ssm_paramet
     token = test_synapse_client.get_sts_storage_token(
         entity=test_synapse_folder_id, permission="read_only", output_format="json"
     )
+    # login with the credentials and list objects
+    s3_client = boto3.session.Session(
+        aws_access_key_id = token["accessKeyId"],
+        aws_secret_access_key = token["secretAccessKey"],
+        aws_session_token = token["sessionToken"]).client("s3")
+    s3_client.list_objects_v2(Bucket=token["bucket"])

--- a/tests/test_setup_external_storage.py
+++ b/tests/test_setup_external_storage.py
@@ -12,11 +12,6 @@ def test_synapse_folder_id(pytestconfig):
 
 
 @pytest.fixture()
-def test_ssm_parameter(pytestconfig):
-    yield pytestconfig.getoption("test_ssm_parameter")
-
-
-@pytest.fixture()
 def test_sts_permission(pytestconfig):
     yield pytestconfig.getoption("test_sts_permission")
 
@@ -31,13 +26,13 @@ def test_setup_external_storage_success(
     test_bucket: str,
     namespace: str,
     test_synapse_folder_id: str,
-    test_ssm_parameter: str,
     test_sts_permission: str,
+    ssm_parameter : str
 ):
     """This test tests that it can get the STS token credentials and view and list the
     files in the S3 bucket location to verify that it has access"""
     test_synapse_client = setup_external_storage.get_synapse_client(
-        ssm_parameter=test_ssm_parameter, aws_session=boto3
+        ssm_parameter=ssm_parameter, aws_session=boto3
     )
     # Get STS credentials
     token = test_synapse_client.get_sts_storage_token(


### PR DESCRIPTION
**Purpose:** This PR fixes the test(s) in `test_setup_external_storage.py` so that it properly tests if STS access credentials can give you list bucket access to a STS-enabled synapse folder.
