### PR TITLE
[ETL-505] Add Garmin transforms to S3 to JSON job

### DIFF
--- a/src/glue/jobs/s3_to_json.py
+++ b/src/glue/jobs/s3_to_json.py
@@ -16,81 +16,232 @@ import zipfile
 import boto3
 from awsglue.utils import getResolvedOptions
 
-def write_file_to_json_dataset(
-        z: zipfile.ZipFile,
-        json_path: str,
-        dataset_identifier: str,
-        metadata: dict,
-        workflow_run_properties: dict,
-        delete_upon_successful_upload: bool=True) -> str:
+DATA_TYPES_WITH_SUBTYPE = ["HealthKitV2Samples", "HealthKitV2Statistics"]
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+def transform_object_to_array_of_objects(
+        json_obj_to_replace: dict,
+        key_name: str,
+        key_type: type,
+        value_name: str,
+        value_type: type,) -> list:
     """
-    Write a JSON from a zipfile to a JSON dataset.
+    Transforms a dictionary object into an array of dictionaries with specified
+    key and value types.
 
-    Metadata fields derived from the file basename are inserted as top-level fields
-    and the NDJSON is written to a JSON dataset in S3.
+    This function takes a dictionary object `json_obj_to_replace` and transforms
+    it into an array of dictionaries, where each dictionary in the array contains
+    two key-value pairs. The keys are specified by the `key_name` and `value_name`
+    parameters, and the values are converted to the corresponding types specified
+    by the `key_type` and `value_type` parameters.
 
-    Args:
-        z (zipfile.Zipfile): The zip archive as provided by the data provider.
-        json_path (str): A JSON path relative to the root of `z`.
-        dataset_identifier (str): The data type of `json_path`.
-        metadata (dict): Metadata derived from the file basename.
-        workflow_run_properties (dict): The workflow arguments
-        delete_upon_successful_upload (bool): Whether to delete the local
-            copy of the JSON file after uploading to S3. Set to False
-            during testing.
+    Parameters:
+        json_obj_to_replace (dict): The input dictionary object to be
+            transformed into an array of dictionaries.
+        key_name (str): The name of the key in the output dictionaries.
+        key_type (type): The type to which the values corresponding to `key_name`
+            should be converted in the output dictionaries.
+        value_name (str): The name of the value in the output dictionaries.
+        value_type (type): The type to which the values corresponding to `value_name`
+            should be converted in the output dictionaries.
 
     Returns:
-        output_path (str) The local path the file was written to.
+        list: An array of dictionaries, where each dictionary contains
+            two key-value pairs:
+              - The key specified by `key_name` with the value converted to the type specified by
+                `key_type`.
+              - The value specified by `value_name` with the value converted to the type specified
+                by `value_type`.
+
+    Examples:
+        json_obj = {'TimeOffsetHeartRateSamples': {"0": 62, "1": 63, "2": 62}}
+        transformed_array = transform_object_to_array_of_objects(
+            json_obj,
+            key_name='OffsetInSeconds',
+            key_type=int,
+            value_name='HeartRate',
+            value_type=int
+        )
+
+        # Resulting `transformed_array`:
+        # [
+        #     {'OffsetInSeconds': 0, 'HeartRate': 62},
+        #     {'OffsetInSeconds': 1, 'HeartRate': 63},
+        #     {'OffsetInSeconds': 2, 'HeartRate': 62},
+        # ]
     """
-    s3_client = boto3.client("s3")
-    logger = logging.getLogger(__name__)
-    os.makedirs(dataset_identifier, exist_ok=True)
-    s3_metadata = metadata.copy()
-    if s3_metadata["start_date"] is None:
-        s3_metadata.pop("start_date")
+    array_of_obj = []
+    value_error = "Failed to cast %s to %s"
+    for k, v in json_obj_to_replace.items():
+        try:
+            key_value = key_type(k)
+        except ValueError:
+            logger.warning(value_error, k,key_type)
+            key_value = None
+        try:
+            value_value = value_type(v)
+        except ValueError:
+            logger.warning(value_error, v, value_type)
+            value_value = None
+        obj = {
+            key_name: key_value,
+            value_name: value_value
+        }
+        array_of_obj.append(obj)
+    return array_of_obj
+
+def transform_json(
+        json_obj: dict,
+        dataset_identifier: str,
+        metadata: dict,) -> dict:
+    """
+    Perform the following transformations:
+
+    For every JSON:
+        - Add an export_start_date property (may be None)
+        - Add an export_end_date property (may be None)
+
+    For JSON whose data types have a subtype:
+        - Add subtype as "Type" property
+
+    For JSON whose data type is "EnrolledParticipants":
+        - Cast "CustomFields.Symptoms" and "CustomFields.Treatments" property
+          to an array. (May be an empty array).
+
+    For relevant Garmin data types:
+        - Some Garmin data types have one or more properties which are objects
+          (usually mapping time to some metric), that would be better formatted
+          as an array of objects. We transform these properties into arrays of
+          objects.
+
+    Args:
+        json_obj (str): A JSON object sourced from the JSON file of this data type.
+        dataset_identifier (str): The data type of `json_obj`.
+        metadata (dict): Metadata derived from the file basename.
+
+    Returns:
+        json_obj (dict) The JSON object with the relevant transformations applied.
+    """
+    if metadata["start_date"] is not None:
+        json_obj["export_start_date"] = metadata["start_date"].isoformat()
     else:
-        s3_metadata["start_date"] = metadata["start_date"].isoformat()
-    s3_metadata["end_date"] = metadata["end_date"].isoformat()
-    data_types_with_subtype = ["HealthKitV2Samples", "HealthKitV2Statistics"]
-    data = []
-    with z.open(json_path, "r") as p:
-        for json_line in p:
-            j = json.loads(json_line)
-            j["export_start_date"] = s3_metadata.get("start_date")
-            j["export_end_date"] = s3_metadata.get("end_date")
-            if dataset_identifier in data_types_with_subtype:
-                # This puts the `Type` property back where Apple intended it to be
-                j["Type"] = metadata["subtype"]
-            if dataset_identifier == "SymptomLog":
-                # Load JSON string as dict
-                j["Value"] = json.loads(j["Value"])
-            if dataset_identifier == "EnrolledParticipants":
-                for field_name in ["Symptoms", "Treatments"]:
-                    if (
-                            field_name in j["CustomFields"]
-                            and isinstance(j["CustomFields"][field_name], str)
-                       ):
-                        if len(j["CustomFields"][field_name]) > 0:
-                            # This JSON string was written in a couple different ways
-                            # in the testing data: "[{\\\"id\\\": ..." and "[{\"id\": ..."
-                            # or just an empty string. It's not really clear which format
-                            # is intended, (The example they provided has it written as
-                            # an object rather than a string, so...).
-                            try:
-                                j["CustomFields"][field_name] = json.loads(
-                                        j["CustomFields"][field_name]
-                                )
-                            except json.JSONDecodeError as e:
-                                # If it's not propertly formatted JSON, then we
-                                # can't read it, and instead store an empty list
-                                logger.warning(f"Problem CustomFields.{field_name}: "
-                                               f"{j['CustomFields'][field_name]}")
-                                logger.warning(str(e))
-                                j["CustomFields"][field_name] = []
-                        else:
-                            j["CustomFields"][field_name] = []
-            data.append(j)
-    if dataset_identifier in data_types_with_subtype:
+        json_obj["export_start_date"] = None
+    json_obj["export_end_date"] = metadata.get("end_date").isoformat()
+    if dataset_identifier in DATA_TYPES_WITH_SUBTYPE:
+        # This puts the `Type` property back where Apple intended it to be
+        json_obj["Type"] = metadata["subtype"]
+    if dataset_identifier == "SymptomLog":
+        # Load JSON string as dict
+        json_obj["Value"] = json.loads(json_obj["Value"])
+    if dataset_identifier == "EnrolledParticipants":
+        for field_name in ["Symptoms", "Treatments"]:
+            if (
+                    field_name in json_obj["CustomFields"]
+                    and isinstance(json_obj["CustomFields"][field_name], str)
+               ):
+                if len(json_obj["CustomFields"][field_name]) > 0:
+                    # This JSON string was written in a couple different ways
+                    # in the testing data: "[{\\\"id\\\": ..." and "[{\"id\": ..."
+                    # or just an empty string. It's not really clear which format
+                    # is intended, (The example they provided has it written as
+                    # an object rather than a string, so...).
+                    try:
+                        json_obj["CustomFields"][field_name] = json.loads(
+                                json_obj["CustomFields"][field_name]
+                        )
+                    except json.JSONDecodeError as e:
+                        # If it's not propertly formatted JSON, then we
+                        # can't read it, and instead store an empty list
+                        logger.warning(f"Problem CustomFields.{field_name}: "
+                                       f"{json_obj['CustomFields'][field_name]}")
+                        logger.warning(str(e))
+                        json_obj["CustomFields"][field_name] = []
+                else:
+                    json_obj["CustomFields"][field_name] = []
+    garmin_transform_types = {
+            "GarminDailySummary": {
+                "TimeOffsetHeartRateSamples": (("OffsetInSeconds", int), ("HeartRate", int))
+            },
+            "GarminHrvSummary": {
+                "HrvValues": (("OffsetInSeconds", int), ("Hrv", int))
+            },
+            "GarminPulseOxSummary": {
+                "TimeOffsetSpo2Values": (("OffsetInSeconds", int), ("Spo2Value", int))
+            },
+            "GarminRespirationSummary": {
+                "TimeOffsetEpochToBreaths": (("OffsetInSeconds", int), ("Breaths", float))
+            },
+            "GarminSleepSummary": {
+                "TimeOffsetSleepSpo2": (("OffsetInSeconds", int), ("Spo2Value", int)),
+                "TimeOffsetSleepRespiration": (("OffsetInSeconds", int), ("Breaths", float))
+            },
+            "GarminStressDetailSummary": {
+                "TimeOffsetStressLevelValues": (("OffsetInSeconds", int), ("StressLevel", int)),
+                "TimeOffsetBodyBatteryValues": (("OffsetInSeconds", int), ("BodyBattery", int))
+            },
+            "GarminThirdPartyDailySummary": {
+                "TimeOffsetHeartRateSamples": (("OffsetInSeconds", int), ("HeartRate", int))
+            },
+            "GarminHealthSnapshotSummary": {
+                "Summaries.EpochSummaries": (("OffsetInSeconds", int), ("Value", float))
+            }
+    }
+    if dataset_identifier in garmin_transform_types:
+        this_data_type = garmin_transform_types[dataset_identifier]
+        for prop in this_data_type:
+            key_name = this_data_type[prop][0][0]
+            key_type = this_data_type[prop][0][1]
+            value_name = this_data_type[prop][1][0]
+            value_type = this_data_type[prop][1][1]
+            property_hierarchy = prop.split(".")
+            # consider implementing recursive solution if necessary
+            if len(property_hierarchy) == 1:
+                prop_name = property_hierarchy[0]
+                if prop_name in json_obj:
+                    array_of_obj = transform_object_to_array_of_objects(
+                            json_obj_to_replace=json_obj[prop_name],
+                            key_name=key_name,
+                            key_type=key_type,
+                            value_name=value_name,
+                            value_type=value_type
+                    )
+                    json_obj[prop_name] = array_of_obj
+            if len(property_hierarchy) == 2:
+                prop_name = property_hierarchy[0]
+                sub_prop_name = property_hierarchy[1]
+                if prop_name in json_obj:
+                    for obj in json_obj[prop_name]:
+                        if sub_prop_name in obj:
+                            array_of_obj = transform_object_to_array_of_objects(
+                                        json_obj_to_replace=obj[sub_prop_name],
+                                        key_name=key_name,
+                                        key_type=key_type,
+                                        value_name=value_name,
+                                        value_type=value_type
+                            )
+                            obj[sub_prop_name] = array_of_obj
+    return json_obj
+
+def get_output_filename(metadata: dict) -> str:
+    """
+    Get a formatted file name.
+
+    The format depends on which metadata fields we have available to us.
+    Metadata fields we can potentially use:
+        - type
+        - subtype
+        - start_date
+        - end_date
+
+    Args:
+        metadata (dict): Metadata derived from the file basename.
+
+    Return:
+        str: A formatted file name.
+    """
+    if metadata["type"] in DATA_TYPES_WITH_SUBTYPE:
         output_fname = "{}_{}_{}-{}.ndjson".format(
                 metadata["type"],
                 metadata["subtype"],
@@ -108,12 +259,61 @@ def write_file_to_json_dataset(
                 metadata["start_date"].strftime("%Y%m%d"),
                 metadata["end_date"].strftime("%Y%m%d")
         )
-    output_path = os.path.join(dataset_identifier, output_fname)
+    return output_fname
+
+def write_file_to_json_dataset(
+        z: zipfile.ZipFile,
+        json_path: str,
+        dataset_identifier: str,
+        metadata: dict,
+        workflow_run_properties: dict,
+        delete_upon_successful_upload: bool=True) -> str:
+    """
+    Write a JSON from a zipfile to a JSON dataset.
+
+    Metadata fields derived from the file basename are inserted as top-level fields,
+    other fields are transformed (see `transform_json`). The resulting NDJSON is written
+    to a JSON dataset in S3.
+
+    Args:
+        z (zipfile.Zipfile): The zip archive as provided by the data provider.
+        json_path (str): A JSON path relative to the root of `z`.
+        dataset_identifier (str): The data type of `json_path`.
+        metadata (dict): Metadata derived from the file basename.
+        workflow_run_properties (dict): The workflow arguments
+        delete_upon_successful_upload (bool): Whether to delete the local
+            copy of the JSON file after uploading to S3. Set to False
+            during testing.
+
+    Returns:
+        output_path (str) The local path the file was written to.
+    """
+    s3_client = boto3.client("s3")
+    os.makedirs(dataset_identifier, exist_ok=True)
+    s3_metadata = metadata.copy()
+    if s3_metadata["start_date"] is None:
+        s3_metadata.pop("start_date")
+    else:
+        s3_metadata["start_date"] = metadata["start_date"].isoformat()
+    s3_metadata["end_date"] = metadata["end_date"].isoformat()
+    data = []
+    with z.open(json_path, "r") as p:
+        for json_line in p:
+            json_obj = json.loads(json_line)
+            json_obj = transform_json(
+                    json_obj=json_obj,
+                    dataset_identifier=dataset_identifier,
+                    metadata=metadata
+            )
+            data.append(json_obj)
+    output_filename = get_output_filename(metadata=metadata)
+    output_path = os.path.join(dataset_identifier, output_filename)
     s3_output_key = os.path.join(
         workflow_run_properties["namespace"],
         workflow_run_properties["json_prefix"],
         f"dataset={dataset_identifier}",
-        output_fname)
+        output_filename
+    )
     logger.debug("Output Key: %s", s3_output_key)
     with open(output_path, "w") as f_out:
         for record in data:
@@ -123,7 +323,8 @@ def write_file_to_json_dataset(
                 Body = f_in,
                 Bucket = workflow_run_properties["json_bucket"],
                 Key = s3_output_key,
-                Metadata = s3_metadata)
+                Metadata = s3_metadata
+        )
         logger.debug("S3 Put object response: %s", json.dumps(response))
     if delete_upon_successful_upload:
         os.remove(output_path)
@@ -147,8 +348,6 @@ def get_metadata(basename: str) -> dict:
                 which in this case is HealthKitV2Samples or HealthKitV2Samples_Deleted
                 or HealthKitV2Statistics).
     """
-    logger = logging.getLogger(__name__)
-    data_types_with_subtype = ["HealthKitV2Samples", "HealthKitV2Statistics"]
     metadata = {}
     basename_components = os.path.splitext(basename)[0].split("_")
     metadata["type"] = basename_components[0]
@@ -162,7 +361,7 @@ def get_metadata(basename: str) -> dict:
         metadata["start_date"] = None
         metadata["end_date"] = \
                 datetime.datetime.strptime(basename_components[-1], "%Y%m%d")
-    if metadata["type"] in data_types_with_subtype:
+    if metadata["type"] in DATA_TYPES_WITH_SUBTYPE:
         metadata["subtype"] = basename_components[1]
     if (
         metadata["type"]
@@ -195,7 +394,6 @@ def process_record(
     Returns:
         None
     """
-    logger = logging.getLogger(__name__)
     with zipfile.ZipFile(io.BytesIO(s3_obj["Body"])) as z:
         non_empty_contents = [
                 f.filename for f in z.filelist
@@ -218,10 +416,6 @@ def process_record(
                     workflow_run_properties=workflow_run_properties)
 
 def main() -> None:
-    # Configure logger
-    logging.basicConfig()
-    logger = logging.getLogger(__name__)
-    logger.setLevel(logging.DEBUG)
 
     # Instantiate boto clients
     glue_client = boto3.client("glue")

--- a/tests/test_s3_to_json.py
+++ b/tests/test_s3_to_json.py
@@ -83,44 +83,299 @@ class TestS3ToJsonS3:
         }
         return json_file_basenames
 
-    def test_write_healthkitv2samples_file_to_json_dataset(self, s3_obj, namespace, monkeypatch):
-        monkeypatch.setattr("boto3.client", lambda x: MockAWSClient())
+    def test_transform_object_to_array_of_objects(self):
+        json_obj_to_replace = {
+                "0": 60.0,
+                "1": 61.2,
+                "2": "99"
+        }
+        transformed_object = s3_to_json.transform_object_to_array_of_objects(
+                json_obj_to_replace=json_obj_to_replace,
+                key_name="key",
+                key_type=int,
+                value_name="value",
+                value_type=int
+        )
+        expected_object = [
+                {
+                    "key": 0,
+                    "value": 60
+                },
+                {
+                    "key": 1,
+                    "value": 61
+                },
+                {
+                    "key":2,
+                    "value": 99
+                }
+        ]
+        assert all([obj in expected_object for obj in transformed_object])
+
+    def test_transform_json_generic(self):
         sample_metadata = {
-            "Metadata": {
+                "type": "FitbitDevices",
+                "start_date": datetime.datetime(2022, 1, 12, 0, 0),
+                "end_date": datetime.datetime(2023, 1, 14, 0, 0),
+        }
+        transformed_json = s3_to_json.transform_json(
+                json_obj={},
+                dataset_identifier=sample_metadata["type"],
+                metadata=sample_metadata
+        )
+
+        assert (
+            sample_metadata["start_date"].isoformat()
+            == transformed_json["export_start_date"]
+        )
+        assert (
+            sample_metadata["end_date"].isoformat()
+            == transformed_json["export_end_date"]
+        )
+
+    def test_transform_json_with_subtype(self):
+        sample_metadata = {
                 "type": "HealthKitV2Samples",
                 "start_date": datetime.datetime(2022, 1, 12, 0, 0),
                 "end_date": datetime.datetime(2023, 1, 14, 0, 0),
                 "subtype": "Weight",
-            }
         }
-        workflow_run_properties = {
-            "namespace": namespace,
-            "json_prefix": "raw-json",
-            "json_bucket": "json-bucket",
-        }
-        with zipfile.ZipFile(io.BytesIO(s3_obj["Body"])) as z:
-            output_file = s3_to_json.write_file_to_json_dataset(
-                z=z,
-                json_path="HealthKitV2Samples_Weight_20230112-20230114.json",
-                dataset_identifier="HealthKitV2Samples",
-                metadata=sample_metadata["Metadata"],
-                workflow_run_properties=workflow_run_properties,
-                delete_upon_successful_upload=False,
-            )
+        transformed_json = s3_to_json.transform_json(
+                json_obj={},
+                dataset_identifier=sample_metadata["type"],
+                metadata=sample_metadata
+        )
 
-            with open(output_file, "r") as f_out:
-                for json_line in f_out:
-                    metadata = json.loads(json_line)
-                    assert sample_metadata["Metadata"]["subtype"] == metadata["Type"]
-                    assert (
-                        sample_metadata["Metadata"]["start_date"].isoformat()
-                        == metadata["export_start_date"]
-                    )
-                    assert (
-                        sample_metadata["Metadata"]["end_date"].isoformat()
-                        == metadata["export_end_date"]
-                    )
-                    break
+        assert sample_metadata["subtype"] == transformed_json["Type"]
+        assert (
+            sample_metadata["start_date"].isoformat()
+            == transformed_json["export_start_date"]
+        )
+        assert (
+            sample_metadata["end_date"].isoformat()
+            == transformed_json["export_end_date"]
+        )
+
+    def test_transform_json_symptom_log(self):
+        sample_metadata = {
+                "type": "SymptomLog",
+                "start_date": datetime.datetime(2022, 1, 12, 0, 0),
+                "end_date": datetime.datetime(2023, 1, 14, 0, 0),
+        }
+        transformed_value = {"a": 1, "b": 2}
+        transformed_json = s3_to_json.transform_json(
+                json_obj={"Value": json.dumps(transformed_value)},
+                dataset_identifier=sample_metadata["type"],
+                metadata=sample_metadata
+        )
+
+        assert (
+            sample_metadata["start_date"].isoformat()
+            == transformed_json["export_start_date"]
+        )
+        assert (
+            sample_metadata["end_date"].isoformat()
+            == transformed_json["export_end_date"]
+        )
+        assert transformed_json["Value"] == transformed_value
+
+    def test_transform_json_enrolled_participants_str(self):
+        sample_symptoms = {"id": "123", "symptom": "sick"}
+        sample_metadata = {
+                "type": "EnrolledParticipants",
+                "start_date": datetime.datetime(2022, 1, 12, 0, 0),
+                "end_date": datetime.datetime(2023, 1, 14, 0, 0),
+        }
+        transformed_json = s3_to_json.transform_json(
+                json_obj={
+                    "CustomFields": {
+                        "Symptoms": json.dumps(sample_symptoms)
+                    }
+                },
+                dataset_identifier=sample_metadata["type"],
+                metadata=sample_metadata
+        )
+
+        assert (
+            sample_metadata["start_date"].isoformat()
+            == transformed_json["export_start_date"]
+        )
+        assert (
+            sample_metadata["end_date"].isoformat()
+            == transformed_json["export_end_date"]
+        )
+        assert all(
+                [
+                    item in transformed_json["CustomFields"]["Symptoms"].items()
+                    for item in sample_symptoms.items()
+                ]
+        )
+
+    def test_transform_json_enrolled_participants_malformatted_str(self):
+        sample_metadata = {
+                "type": "EnrolledParticipants",
+                "start_date": datetime.datetime(2022, 1, 12, 0, 0),
+                "end_date": datetime.datetime(2023, 1, 14, 0, 0),
+        }
+        transformed_json = s3_to_json.transform_json(
+                json_obj={
+                    "CustomFields": {
+                        "Symptoms": r'[{\\\"id\\\": "123", \\\"symptom\\\": "sick"}]'
+                    }
+                },
+                dataset_identifier=sample_metadata["type"],
+                metadata=sample_metadata
+        )
+
+        assert (
+            sample_metadata["start_date"].isoformat()
+            == transformed_json["export_start_date"]
+        )
+        assert (
+            sample_metadata["end_date"].isoformat()
+            == transformed_json["export_end_date"]
+        )
+        assert transformed_json["CustomFields"]["Symptoms"] == []
+
+    def test_transform_json_garmin_one_level_down(self):
+        time_offset_heartrate_samples = {
+                "0": 60.0,
+                "1": 61.0,
+                "2": 99.0
+        }
+        transformed_time_offset_heartrate_samples = [
+                {
+                    "OffsetInSeconds": 0,
+                    "HeartRate": 60
+                },
+                {
+                    "OffsetInSeconds": 1,
+                    "HeartRate": 61
+                },
+                {
+                    "OffsetInSeconds":2,
+                    "HeartRate": 99
+                }
+        ]
+        sample_metadata = {
+                "type": "GarminDailySummary",
+                "start_date": datetime.datetime(2022, 1, 12, 0, 0),
+                "end_date": datetime.datetime(2023, 1, 14, 0, 0),
+        }
+        transformed_json = s3_to_json.transform_json(
+                json_obj={"TimeOffsetHeartRateSamples": time_offset_heartrate_samples},
+                dataset_identifier=sample_metadata["type"],
+                metadata=sample_metadata
+        )
+
+        assert (
+            sample_metadata["start_date"].isoformat()
+            == transformed_json["export_start_date"]
+        )
+        assert (
+            sample_metadata["end_date"].isoformat()
+            == transformed_json["export_end_date"]
+        )
+        assert all(
+                [
+                    obj in transformed_json["TimeOffsetHeartRateSamples"]
+                    for obj in transformed_time_offset_heartrate_samples
+                ]
+        )
+
+    def test_transform_json_garmin_two_levels_down(self):
+        epoch_summaries = {
+                "0": 60.0,
+                "1": 61.0,
+                "2": 99.0
+        }
+        transformed_epoch_summaries = [
+                {
+                    "OffsetInSeconds": 0,
+                    "Value": 60.0
+                },
+                {
+                    "OffsetInSeconds": 1,
+                    "Value": 61.0
+                },
+                {
+                    "OffsetInSeconds":2,
+                    "Value": 99.0
+                }
+        ]
+        sample_metadata = {
+                "type": "GarminHealthSnapshotSummary",
+                "start_date": datetime.datetime(2022, 1, 12, 0, 0),
+                "end_date": datetime.datetime(2023, 1, 14, 0, 0),
+        }
+        transformed_json = s3_to_json.transform_json(
+                json_obj={
+                    "Summaries": [
+                        {
+                            "EpochSummaries": epoch_summaries,
+                            "Dummy": 1
+                        },
+                        {
+                            "EpochSummaries": epoch_summaries,
+                        },
+                    ]
+                },
+                dataset_identifier=sample_metadata["type"],
+                metadata=sample_metadata
+        )
+
+        assert (
+            sample_metadata["start_date"].isoformat()
+            == transformed_json["export_start_date"]
+        )
+        assert (
+            sample_metadata["end_date"].isoformat()
+            == transformed_json["export_end_date"]
+        )
+        assert all(
+                [
+                    obj in transformed_json["Summaries"][0]["EpochSummaries"]
+                    for obj in transformed_epoch_summaries
+                ]
+        )
+        # Check that this worked for another object in the array
+        # and not just the first object
+        assert all(
+                [
+                    obj in transformed_json["Summaries"][1]["EpochSummaries"]
+                    for obj in transformed_epoch_summaries
+                ]
+        )
+        # Check that other properties were not affected
+        assert transformed_json["Summaries"][0]["Dummy"] == 1
+
+    def test_get_output_filename_generic(self):
+        sample_metadata = {
+                "type": "FitbitDevices",
+                "start_date": datetime.datetime(2022, 1, 12, 0, 0),
+                "end_date": datetime.datetime(2023, 1, 14, 0, 0),
+        }
+        output_filename = s3_to_json.get_output_filename(metadata=sample_metadata)
+        assert output_filename == "FitbitDevices_20220112-20230114.ndjson"
+
+    def test_get_output_filename_no_start_date(self):
+        sample_metadata = {
+                "type": "EnrolledParticipants",
+                "start_date": None,
+                "end_date": datetime.datetime(2023, 1, 14, 0, 0),
+        }
+        output_filename = s3_to_json.get_output_filename(metadata=sample_metadata)
+        assert output_filename == "EnrolledParticipants_20230114.ndjson"
+
+    def test_get_output_filename_subtype(self):
+        sample_metadata = {
+                "type": "HealthKitV2Samples",
+                "subtype": "Weight",
+                "start_date": datetime.datetime(2022, 1, 12, 0, 0),
+                "end_date": datetime.datetime(2023, 1, 14, 0, 0),
+        }
+        output_filename = s3_to_json.get_output_filename(metadata=sample_metadata)
+        assert output_filename == "HealthKitV2Samples_Weight_20220112-20230114.ndjson"
 
     def test_write_file_to_json_dataset_delete_local_copy(self, s3_obj, namespace, monkeypatch):
         monkeypatch.setattr("boto3.client", lambda x: MockAWSClient())
@@ -148,81 +403,6 @@ class TestS3ToJsonS3:
             )
 
         assert not os.path.exists(output_file)
-
-    def test_write_symptom_log_file_to_json_dataset(self, s3_obj, namespace, monkeypatch):
-        monkeypatch.setattr("boto3.client", lambda x: MockAWSClient())
-        sample_metadata = {
-            "Metadata": {
-                "type": "SymptomLog",
-                "start_date": datetime.datetime(2022, 1, 12, 0, 0),
-                "end_date": datetime.datetime(2023, 1, 14, 0, 0)
-            }
-        }
-        workflow_run_properties = {
-            "namespace": namespace,
-            "json_prefix": "raw-json",
-            "json_bucket": "json-bucket",
-        }
-        with zipfile.ZipFile(io.BytesIO(s3_obj["Body"])) as z:
-            output_file = s3_to_json.write_file_to_json_dataset(
-                z=z,
-                json_path="SymptomLog_20230112-20230114.json",
-                dataset_identifier="SymptomLog",
-                metadata=sample_metadata["Metadata"],
-                workflow_run_properties=workflow_run_properties,
-                delete_upon_successful_upload=False,
-            )
-
-            with open(output_file, "r") as f_out:
-                for json_line in f_out:
-                    metadata = json.loads(json_line)
-                    assert (
-                        sample_metadata["Metadata"]["start_date"].isoformat()
-                        == metadata["export_start_date"]
-                    )
-                    assert (
-                        sample_metadata["Metadata"]["end_date"].isoformat()
-                        == metadata["export_end_date"]
-                    )
-                    assert isinstance(metadata['Value'], dict)
-                    break
-
-    def test_write_enrolled_participants_file_to_json_dataset(self, s3_obj, namespace, monkeypatch):
-        monkeypatch.setattr("boto3.client", lambda x: MockAWSClient())
-        sample_metadata = {
-            "Metadata": {
-                "type": "EnrolledParticipants",
-                "start_date": None,
-                "end_date": datetime.datetime(2023, 1, 14, 0, 0)
-            }
-        }
-        workflow_run_properties = {
-            "namespace": namespace,
-            "json_prefix": "raw-json",
-            "json_bucket": "json-bucket",
-        }
-        with zipfile.ZipFile(io.BytesIO(s3_obj["Body"])) as z:
-            output_file = s3_to_json.write_file_to_json_dataset(
-                z=z,
-                json_path="EnrolledParticipants_20230114.json",
-                dataset_identifier="EnrolledParticipants",
-                metadata=sample_metadata["Metadata"],
-                workflow_run_properties=workflow_run_properties,
-                delete_upon_successful_upload=False,
-            )
-
-            with open(output_file, "r") as f_out:
-                for json_line in f_out:
-                    metadata = json.loads(json_line)
-                    assert (
-                        sample_metadata["Metadata"]["end_date"].isoformat()
-                        == metadata["export_end_date"]
-                    )
-                    if "Symptoms" in metadata['CustomFields']:
-                        assert isinstance(metadata['CustomFields']['Symptoms'], list)
-                    if "Treatments" in metadata['CustomFields']:
-                        assert isinstance(metadata['CustomFields']['Treatments'], list)
-                    break
 
     def test_write_file_to_json_dataset_record_consistency(self, s3_obj, namespace, monkeypatch):
         monkeypatch.setattr("boto3.client", lambda x: MockAWSClient())
@@ -263,7 +443,6 @@ class TestS3ToJsonS3:
                     output_line_cnt += 1
             # gets line count of input json and exported json and checks the two
             assert input_line_cnt == output_line_cnt
-
 
     def test_get_metadata_startdate_enddate(self, json_file_basenames_dict):
         basename = json_file_basenames_dict["HealthKitV2Samples_Deleted"]


### PR DESCRIPTION
In addition to the Garmin transforms, I refactored the S3 to JSON job to be more functional. What used to just be
* `write_file_to_json_dataset`

has been split up into three different functions:
* `transform_json` - which takes care of any inserts/updates to the JSON data
* `transform_object_to_array_of_objects` - which is a helper function for `transform_json`
* `get_output_filename` - which takes care of filename / S3 object name formatting.

As a result of refactoring in the job, the tests have been refactored as well. Some tests were deleted and replaced with a more specific test.