### PR TITLE
Add an owner.txt to the ingestion bucket

### DIFF
--- a/config/develop/namespaced/s3-ingestion-bucket-owner-txt.yaml
+++ b/config/develop/namespaced/s3-ingestion-bucket-owner-txt.yaml
@@ -1,0 +1,11 @@
+template:
+  type: file
+  path: s3-owner-txt.yaml
+stack_name: "{{ stack_group_config.namespace }}-recover-dev-ingestion-bucket-owner-txt"
+dependencies:
+  - develop/cfn-s3objects-macro.yaml
+  - develop/s3-ingestion.yaml
+parameters:
+  BucketName: !stack_output_external recover-dev-ingestion-bucket::Bucket
+  SynapseIds: "3461799,3455604" # RecoverETL and synapse-service-sysbio-recover-data-storage-01
+  OwnerTxtKeyPrefix: {{ stack_group_config.namespace }}

--- a/config/prod/namespaced/s3-ingestion-bucket-owner-txt.yaml
+++ b/config/prod/namespaced/s3-ingestion-bucket-owner-txt.yaml
@@ -1,0 +1,10 @@
+template:
+  type: file
+  path: s3-owner-txt.yaml
+stack_name: "{{ stack_group_config.namespace }}-recover-ingestion-bucket-owner-txt"
+dependencies:
+  - prod/cfn-s3objects-macro.yaml
+  - prod/s3-ingestion.yaml
+parameters:
+  BucketName: !stack_output_external recover-ingestion-bucket::Bucket
+  SynapseIds: "3461799,3455604" # RecoverETL and synapse-service-sysbio-recover-data-storage-01


### PR DESCRIPTION
Synapse already has read/write access to the ingestion bucket, so the only thing to do to enable the use of the bucket as an external storage location is to write an owner.txt.

In develop, owner.txt is written to `main`.
In prod, owner.txt is written to the bucket root. This is where production data (e.g., `adults\/v1` and `pediatric\/v1`) already live.