### PR TITLE
[ETL-535] Set up SQS to receive S3 event notification

### DIFF
--- a/config/develop/namespaced/s3-event-config-lambda.yaml
+++ b/config/develop/namespaced/s3-event-config-lambda.yaml
@@ -10,7 +10,7 @@ stack_name: '{{ stack_group_config.namespace }}-lambda-S3EventConfig'
 stack_tags: {{ stack_group_config.default_stack_tags }}
 parameters:
   Namespace: {{ stack_group_config.namespace }}
-  S3ToGlueDestinationArn: !stack_output_external "{{ stack_group_config.namespace }}-lambda-S3ToGlue::S3ToGlueFunctionArn"
+  S3ToGlueDestinationArn: !stack_output_external "{{ stack_group_config.namespace }}-sqs-S3ToLambda::PrimaryQueueArn"
   S3ToGlueDestinationType: "Queue"
   S3EventConfigRoleArn: !stack_output_external "{{ stack_group_config.namespace }}-s3-event-config-lambda-role::RoleArn"
   S3SourceBucketName: {{ stack_group_config.input_bucket_name }}

--- a/config/develop/namespaced/s3-event-config-lambda.yaml
+++ b/config/develop/namespaced/s3-event-config-lambda.yaml
@@ -10,6 +10,7 @@ stack_name: '{{ stack_group_config.namespace }}-lambda-S3EventConfig'
 stack_tags: {{ stack_group_config.default_stack_tags }}
 parameters:
   Namespace: {{ stack_group_config.namespace }}
-  S3ToGlueFunctionArn: !stack_output_external "{{ stack_group_config.namespace }}-lambda-S3ToGlue::S3ToGlueFunctionArn"
+  S3ToGlueDestinationArn: !stack_output_external "{{ stack_group_config.namespace }}-lambda-S3ToGlue::S3ToGlueFunctionArn"
+  S3ToGlueDestinationType: "Queue"
   S3EventConfigRoleArn: !stack_output_external "{{ stack_group_config.namespace }}-s3-event-config-lambda-role::RoleArn"
   S3SourceBucketName: {{ stack_group_config.input_bucket_name }}

--- a/config/develop/namespaced/sqs-queue.yaml
+++ b/config/develop/namespaced/sqs-queue.yaml
@@ -2,8 +2,8 @@ template:
   path: sqs-queue.yaml
 parameters:
   MessageRetentionPeriod: '86400'
-  ReceiveMessageWaitTimeSeconds: 20
-  VisibilityTimeout: 120
+  ReceiveMessageWaitTimeSeconds: '20'
+  VisibilityTimeout: '120'
   S3SourceBucketArn: !stack_output_external recover-dev-input-bucket::BucketArn
 dependencies:
   - develop/namespaced/s3-to-glue-lambda.yaml

--- a/config/develop/namespaced/sqs-queue.yaml
+++ b/config/develop/namespaced/sqs-queue.yaml
@@ -1,0 +1,13 @@
+template:
+  path: sqs-queue.yaml
+parameters:
+  MessageRetentionPeriod: '86400'
+  ReceiveMessageWaitTimeSeconds: 20
+  VisibilityTimeout: 120
+  S3SourceBucketArn: !stack_output_external recover-dev-input-bucket::BucketArn
+dependencies:
+  - develop/namespaced/s3-to-glue-lambda.yaml
+  - develop/s3-input-bucket.yaml
+stack_name: '{{ stack_group_config.namespace }}-sqs-S3ToLambda'
+stack_tags:
+  {{ stack_group_config.default_stack_tags }}

--- a/config/prod/namespaced/s3-event-config-lambda.yaml
+++ b/config/prod/namespaced/s3-event-config-lambda.yaml
@@ -10,6 +10,7 @@ stack_name: '{{ stack_group_config.namespace }}-lambda-S3EventConfig'
 stack_tags: {{ stack_group_config.default_stack_tags }}
 parameters:
   Namespace: {{ stack_group_config.namespace }}
-  S3ToGlueFunctionArn: !stack_output_external "{{ stack_group_config.namespace }}-lambda-S3ToGlue::S3ToGlueFunctionArn"
+  S3ToGlueDestinationArn: !stack_output_external "{{ stack_group_config.namespace }}-sqs-S3ToLambda::PrimaryQueueArn"
+  S3ToGlueDestinationType: "Queue"
   S3EventConfigRoleArn: !stack_output_external "{{ stack_group_config.namespace }}-s3-event-config-lambda-role::RoleArn"
   S3SourceBucketName: {{ stack_group_config.input_bucket_name }}

--- a/config/prod/namespaced/sqs-queue.yaml
+++ b/config/prod/namespaced/sqs-queue.yaml
@@ -1,0 +1,13 @@
+template:
+  path: sqs-queue.yaml
+parameters:
+  MessageRetentionPeriod: '86400'
+  ReceiveMessageWaitTimeSeconds: '20'
+  VisibilityTimeout: '120'
+  S3SourceBucketArn: !stack_output_external recover-input-bucket::BucketArn
+dependencies:
+  - prod/namespaced/s3-to-glue-lambda.yaml
+  - prod/s3-input-bucket.yaml
+stack_name: '{{ stack_group_config.namespace }}-sqs-S3ToLambda'
+stack_tags:
+  {{ stack_group_config.default_stack_tags }}

--- a/src/lambda_function/s3_event_config/README.md
+++ b/src/lambda_function/s3_event_config/README.md
@@ -4,8 +4,13 @@ The s3_event_config lambda is triggered by a github action during deployment or 
 
 It will then put a S3 event notification configuration into
 the input data bucket which allows the input data bucket to
-trigger the S3 to JSON lambda with S3 new object notifications whenever new objects are added
+trigger a specific destination type with S3 new object notifications whenever new objects are added
 to it and eventually lead to the start of the S3-to-JSON workflow.
+
+Currently **only** the following destination types are supported:
+
+- Lambda Function
+- SQS queue
 
 ## Event format
 
@@ -22,6 +27,8 @@ Where the allowed RequestType values are:
 - "Create"
 - "Update"
 - "Delete"
+
+You can test the lambda by going to the AWS console for the lambda function, pasting the above sample event in and triggering the function. Any updates should then be visible in the input bucket's event config to confirm it was successful.
 
 ## Launching Lambda stack in AWS
 

--- a/src/lambda_function/s3_event_config/template.yaml
+++ b/src/lambda_function/s3_event_config/template.yaml
@@ -18,6 +18,9 @@ Parameters:
   S3ToGlueDestinationType:
     Type: String
     Description: The S3 Event Config Destination Type
+    AllowedValues:
+      - "Queue"
+      - "LambdaFunction"
 
   S3EventConfigRoleArn:
     Type: String

--- a/src/lambda_function/s3_event_config/template.yaml
+++ b/src/lambda_function/s3_event_config/template.yaml
@@ -11,9 +11,13 @@ Parameters:
     Description: >-
       The namespace string used for the bucket key prefix
 
-  S3ToGlueFunctionArn:
+  S3ToGlueDestinationArn:
     Type: String
-    Description: Arn for the S3 Event Config Lambda Function
+    Description: Arn for the S3 Event Config Destination
+
+  S3ToGlueDestinationType:
+    Type: String
+    Description: The S3 Event Config Destination Type
 
   S3EventConfigRoleArn:
     Type: String
@@ -43,7 +47,8 @@ Resources:
       Environment:
         Variables:
           S3_SOURCE_BUCKET_NAME: !Ref S3SourceBucketName
-          S3_TO_GLUE_FUNCTION_ARN: !Ref S3ToGlueFunctionArn
+          S3_TO_GLUE_DESTINATION_ARN: !Ref S3ToGlueDestinationArn
+          S3_TO_GLUE_DESTINATION_TYPE: !Ref S3ToGlueDestinationType
           BUCKET_KEY_PREFIX: !Ref Namespace
 
 Outputs:

--- a/templates/sqs-queue.yaml
+++ b/templates/sqs-queue.yaml
@@ -46,6 +46,7 @@ Resources:
         - Sid: Send_Permission
           Effect: Allow
           Principal:
+            Service: s3.amazonaws.com
             AWS: !Sub '${AWS::AccountId}'
           Action:
           - SQS:SendMessage

--- a/templates/sqs-queue.yaml
+++ b/templates/sqs-queue.yaml
@@ -1,0 +1,69 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: >
+  Creates an SQS queue that gets S3 notifications
+
+Parameters:
+
+  MessageRetentionPeriod:
+    Type: Number
+    Default: 1209600
+    Description: How long to retain messages in the primary queue.
+
+  ReceiveMessageWaitTimeSeconds:
+    Type: Number
+    Default: 20
+    Description: The delay between SQS receiving a message and making it available for others to poll
+
+  VisibilityTimeout:
+    Type: Number
+    Default: 120
+    Description: >-
+      How long our lambda has to submit the messages to Glue and
+      delete the message from the SQS queue
+
+  S3SourceBucketArn:
+    Type: String
+    Description: Arn of the S3 bucket where source data are stored.
+
+Resources:
+
+  PrimaryQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      DelaySeconds: 0
+      MessageRetentionPeriod: !Ref MessageRetentionPeriod
+      QueueName: !Sub '${AWS::StackName}-Queue'
+      ReceiveMessageWaitTimeSeconds: !Ref ReceiveMessageWaitTimeSeconds
+      VisibilityTimeout: !Ref VisibilityTimeout
+
+  PrimaryQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Sid: Send_Permission
+          Effect: Allow
+          Principal:
+            AWS: !Sub '${AWS::AccountId}'
+          Action:
+          - SQS:SendMessage
+          Resource: !GetAtt PrimaryQueue.Arn
+          Condition:
+            ArnLike:
+              "aws:SourceArn": !Ref S3SourceBucketArn
+      Queues:
+      - !Ref PrimaryQueue
+
+Outputs:
+
+  PrimaryQueueArn:
+    Value: !GetAtt PrimaryQueue.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-PrimaryQueueArn'
+
+  PrimaryQueueUrl:
+    Value: !Ref PrimaryQueue
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-PrimaryQueueUrl'


### PR DESCRIPTION
**Purpose:** This PR contains initial work done as part of [ETL-532](https://sagebionetworks.jira.com/browse/ETL-532) which led us to move forward with using SQS queue.

This PR only does the following:
- Sets up a working SQS queue that can receive messages from S3 pre-ETL bucket
- Updates the S3 event config lambda so that the S3 pre-ETL bucket can send S3 notifications to a SQS queue

[ETL-532]: https://sagebionetworks.jira.com/browse/ETL-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ