### PR TITLE
[ETL-533] Add `cohort` to data as partition

### DIFF
--- a/config/develop/namespaced/glue-workflow.yaml
+++ b/config/develop/namespaced/glue-workflow.yaml
@@ -6,11 +6,13 @@ dependencies:
   - develop/namespaced/glue-job-S3ToJsonS3.yaml
   - develop/namespaced/glue-job-JSONToParquet.yaml
   - develop/namespaced/glue-job-compare-parquet.yaml
+  - develop/glue-job-role.yaml
 parameters:
   Namespace: {{ stack_group_config.namespace }}
   JsonBucketName: {{ stack_group_config.intermediate_bucket_name }}
   ParquetBucketName: {{ stack_group_config.processed_data_bucket_name }}
   GlueDatabase: !stack_output_external "{{ stack_group_config.namespace }}-glue-tables::DatabaseName"
+  CrawlerRole: !stack_output_external glue-job-role::RoleArn
   S3ToJsonJobName: !stack_output_external "{{ stack_group_config.namespace }}-glue-job-S3ToJsonS3::JobName"
   CompareParquetStagingNamespace: {{ stack_group_config.namespace }}
   CompareParquetMainNamespace: "main"

--- a/config/prod/namespaced/glue-workflow.yaml
+++ b/config/prod/namespaced/glue-workflow.yaml
@@ -6,11 +6,13 @@ dependencies:
   - prod/namespaced/glue-job-S3ToJsonS3.yaml
   - prod/namespaced/glue-job-JSONToParquet.yaml
   - prod/namespaced/glue-job-compare-parquet.yaml
+  - prod/glue-job-role.yaml
 parameters:
   Namespace: {{ stack_group_config.namespace }}
   JsonBucketName: {{ stack_group_config.intermediate_bucket_name }}
   ParquetBucketName: {{ stack_group_config.processed_data_bucket_name }}
   GlueDatabase: !stack_output_external "{{ stack_group_config.namespace }}-glue-tables::DatabaseName"
+  CrawlerRole: !stack_output_external glue-job-role::RoleArn
   S3ToJsonJobName: !stack_output_external "{{ stack_group_config.namespace }}-glue-job-S3ToJsonS3::JobName"
   CompareParquetStagingNamespace: "staging"
   CompareParquetMainNamespace: "main"

--- a/src/glue/jobs/s3_to_json.py
+++ b/src/glue/jobs/s3_to_json.py
@@ -19,8 +19,13 @@ from awsglue.utils import getResolvedOptions
 
 DATA_TYPES_WITH_SUBTYPE = ["HealthKitV2Samples", "HealthKitV2Statistics"]
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
+handler.setFormatter(formatter)
+logger.addHandler(handler)
 
 def transform_object_to_array_of_objects(
         json_obj_to_replace: dict,
@@ -373,7 +378,6 @@ def write_file_to_json_dataset(
             current_file_size = os.path.getsize(current_output_path)
             if current_file_size > file_size_limit:
                 part_number += 1
-                print(f"!!! File is too large, creating new part {part_number}")
                 current_output_path = get_part_path(
                         metadata=metadata,
                         part_number=part_number,

--- a/src/glue/jobs/s3_to_json.py
+++ b/src/glue/jobs/s3_to_json.py
@@ -96,6 +96,7 @@ def transform_object_to_array_of_objects(
 def transform_json(
         json_obj: dict,
         dataset_identifier: str,
+        cohort: str,
         metadata: dict,) -> dict:
     """
     Perform the following transformations:
@@ -103,6 +104,7 @@ def transform_json(
     For every JSON:
         - Add an export_start_date property (may be None)
         - Add an export_end_date property (may be None)
+        - Add a cohort property
 
     For JSON whose data types have a subtype:
         - Add subtype as "Type" property
@@ -120,6 +122,7 @@ def transform_json(
     Args:
         json_obj (str): A JSON object sourced from the JSON file of this data type.
         dataset_identifier (str): The data type of `json_obj`.
+        cohort (str): The cohort which this data associates with.
         metadata (dict): Metadata derived from the file basename.
 
     Returns:
@@ -130,6 +133,7 @@ def transform_json(
     else:
         json_obj["export_start_date"] = None
     json_obj["export_end_date"] = metadata.get("end_date").isoformat()
+    json_obj["cohort"] = cohort
     if dataset_identifier in DATA_TYPES_WITH_SUBTYPE:
         # This puts the `Type` property back where Apple intended it to be
         json_obj["Type"] = metadata["subtype"]
@@ -269,6 +273,7 @@ def get_output_filename(metadata: dict, part_number: int) -> str:
 def transform_block(
         input_json: typing.IO,
         dataset_identifier: str,
+        cohort: str,
         metadata: dict,
         block_size: int=10000):
     """
@@ -283,6 +288,7 @@ def transform_block(
         input_json (typing.IO): A file-like object of the JSON to be transformed.
         dataset_identifier (str): The data type of `input_json`.
         metadata (dict): Metadata derived from the file basename. See `get_metadata`.
+        cohort (str): The cohort which this data associates with.
         block_size (int, optional): The number of records to process in each block.
             Default is 10000.
 
@@ -295,6 +301,7 @@ def transform_block(
         json_obj = transform_json(
                 json_obj=json_obj,
                 dataset_identifier=dataset_identifier,
+                cohort=cohort,
                 metadata=metadata
         )
         block.append(json_obj)
@@ -360,6 +367,7 @@ def write_file_to_json_dataset(
         for transformed_block in transform_block(
                 input_json=input_json,
                 dataset_identifier=dataset_identifier,
+                cohort=cohort,
                 metadata=metadata
         ):
             current_file_size = os.path.getsize(current_output_path)

--- a/src/glue/resources/table_columns.yaml
+++ b/src/glue/resources/table_columns.yaml
@@ -37,6 +37,9 @@ tables:
         Type: string
       - Name: export_end_date
         Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   HealthKitV2Statistics:
     columns:
       - Name: HealthKitStatisticKey
@@ -60,6 +63,9 @@ tables:
       - Name: export_start_date
         Type: string
       - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
         Type: string
   HealthKitV2Samples:
     columns:
@@ -91,6 +97,9 @@ tables:
         Type: string
       - Name: export_end_date
         Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   HealthKitV2Samples_Deleted:
     columns:
       - Name: HealthKitSampleKey
@@ -104,6 +113,9 @@ tables:
       - Name: export_start_date
         Type: string
       - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
         Type: string
   HealthKitV2ActivitySummaries:
     columns:
@@ -134,6 +146,9 @@ tables:
       - Name: export_start_date
         Type: string
       - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
         Type: string
   HealthKitV2Electrocardiogram:
     columns:
@@ -171,6 +186,9 @@ tables:
         Type: string
       - Name: export_end_date
         Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   HealthKitV2Workouts:
     columns:
       - Name: HealthKitWorkoutKey
@@ -199,6 +217,9 @@ tables:
         Type: string
       - Name: export_end_date
         Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   HealthKitV2Heartbeat:
     columns:
       - Name: HealthKitHeartbeatSampleKey
@@ -224,6 +245,9 @@ tables:
       - Name: export_start_date
         Type: string
       - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
         Type: string
   FitbitActivityLogs:
     columns:
@@ -273,6 +297,9 @@ tables:
         Type: string
       - Name: export_end_date
         Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   FitbitDevices:
     columns:
       - Name: ParticipantIdentifier
@@ -290,6 +317,9 @@ tables:
       - Name: export_start_date
         Type: string
       - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
         Type: string
   FitbitDailyData:
     columns:
@@ -359,6 +389,9 @@ tables:
         Type: string
       - Name: export_end_date
         Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   FitbitIntradayCombined:
     columns:
       - Name: ParticipantID
@@ -397,6 +430,9 @@ tables:
         Type: string
       - Name: export_end_date
         Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   FitbitRestingHeartRates:
     columns:
       - Name: ParticipantIdentifier
@@ -410,6 +446,9 @@ tables:
       - Name: export_start_date
         Type: string
       - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
         Type: string
   FitbitSleepLogs:
     columns:
@@ -461,6 +500,9 @@ tables:
         Type: string
       - Name: export_end_date
         Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   GoogleFitSamples:
     columns:
       - Name: GoogleFitSampleKey
@@ -505,6 +547,9 @@ tables:
         Type: string
       - Name: export_end_date
         Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   SymptomLog:
     columns:
       - Name: DatapointKey
@@ -524,6 +569,9 @@ tables:
       - Name: export_start_date
         Type: string
       - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
         Type: string
   GarminActivityDetailsSummary:
     columns:
@@ -552,6 +600,9 @@ tables:
       - Name: export_start_date
         Type: string
       - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
         Type: string
   GarminActivitySummary:
     columns:
@@ -661,6 +712,9 @@ tables:
         Type: string
       - Name: export_end_date
         Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   GarminBloodPressureSummary:
     columns:
       - Name: ParticipantIdentifier
@@ -686,6 +740,9 @@ tables:
       - Name: export_start_date
         Type: string
       - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
         Type: string
   GarminBodyCompositionSummary:
     columns:
@@ -716,6 +773,9 @@ tables:
       - Name: export_start_date
         Type: string
       - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
         Type: string
   GarminDailySummary:
     columns:
@@ -789,6 +849,9 @@ tables:
         Type: string
       - Name: export_end_date
         Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   GarminEpochSummary:
     columns:
       - Name: ParticipantIdentifier
@@ -827,6 +890,9 @@ tables:
         Type: string
       - Name: export_end_date
         Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   GarminHealthSnapshotSummary:
     columns:
       - Name: ParticipantIdentifier
@@ -850,6 +916,9 @@ tables:
       - Name: export_start_date
         Type: string
       - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
         Type: string
   GarminHrvSummary:
     columns:
@@ -878,6 +947,9 @@ tables:
       - Name: export_start_date
         Type: string
       - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
         Type: string
   GarminManuallyUpdatedActivitySummary:
     columns:
@@ -951,6 +1023,9 @@ tables:
         Type: string
       - Name: export_end_date
         Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   GarminMoveIQActivitySummary:
     columns:
       - Name: ParticipantIdentifier
@@ -981,6 +1056,9 @@ tables:
         Type: string
       - Name: export_end_date
         Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   GarminPulseOxSummary:
     columns:
       - Name: ParticipantIdentifier
@@ -1007,6 +1085,9 @@ tables:
         Type: string
       - Name: export_end_date
         Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   GarminRespirationSummary:
     columns:
       - Name: ParticipantIdentifier
@@ -1028,6 +1109,9 @@ tables:
       - Name: export_start_date
         Type: string
       - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
         Type: string
   GarminSleepSummary:
     columns:
@@ -1075,6 +1159,9 @@ tables:
         Type: string
       - Name: export_end_date
         Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   GarminStressDetailSummary:
     columns:
       - Name: ParticipantIdentifier
@@ -1100,6 +1187,9 @@ tables:
       - Name: export_start_date
         Type: string
       - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
         Type: string
   GarminThirdPartyDailySummary:
     columns:
@@ -1149,6 +1239,9 @@ tables:
         Type: string
       - Name: export_end_date
         Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   GarminUserMetricsSummary:
     columns:
       - Name: ParticipantIdentifier
@@ -1170,4 +1263,7 @@ tables:
       - Name: export_start_date
         Type: string
       - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
         Type: string

--- a/src/lambda_function/s3_to_glue/events/generate_test_event.py
+++ b/src/lambda_function/s3_to_glue/events/generate_test_event.py
@@ -88,7 +88,10 @@ def create_event(bucket: str, key: str, key_prefix: str, key_file: str) -> dict:
                 Bucket=bucket,
                 Prefix=key_prefix
         )
-        test_data = [obj["Key"] for obj in test_objects["Contents"]]
+        test_data = [
+                obj["Key"] for obj in test_objects["Contents"]
+                if not obj["Key"].endswith("/")
+        ]
     else:
         test_data = [key]
     s3_event = {

--- a/templates/glue-tables.j2
+++ b/templates/glue-tables.j2
@@ -27,6 +27,7 @@ Resources:
   {% do dataset.update({'table_name': 'dataset_' + v.lower()})%}
   {% set schema = sceptre_user_data.dataset_schemas.tables[v] %}
   {% do dataset.update({'columns': schema['columns']}) %}
+  {% do dataset.update({'partition_keys': schema['partition_keys']}) %}
   {% do dataset.update({'stackname_prefix': '{}'.format(v.replace('_',''))}) %}
   {% do datasets.append(dataset) %}
   {% endfor %}
@@ -53,6 +54,7 @@ Resources:
           compressionType: none
           typeOfData: file
         Retention: 0
+        PartitionKeys: {{ dataset.partition_keys }}
         StorageDescriptor:
           Columns: {{ dataset.columns }}
           Compressed: false

--- a/templates/glue-workflow.j2
+++ b/templates/glue-workflow.j2
@@ -42,6 +42,10 @@ Parameters:
     Description: >-
         Glue database containing Glue tables for use in JSON to Parquet job.
 
+  CrawlerRole:
+    Type: String
+    Description: ARN of the IAM Role the crawler will assume.
+
   S3ToJsonJobName:
     Type: String
     Description: The name of the S3 To JSON Job
@@ -98,17 +102,53 @@ Resources:
     Properties:
       Name: !Sub "${Namespace}-S3ToJsonCompleteTrigger"
       Actions:
-        {% for dataset in datasets if not "HealthKit" in dataset["data_type"] and not "Fitbit" in dataset["data_type"] and not "Google" in dataset["data_type"] and not "Garmin" in dataset["data_type"] %}
-        - JobName: !Sub ${Namespace}-{{ dataset["stackname_prefix"]}}-Job
-          Arguments: {"--glue-table": {{ "{}".format(dataset["table_name"]) }} }
-        {% endfor %}
-      Description: This trigger kicks off every JSON to Parquet job which is not associated with a device and runs after completion of the S3 to JSON job.
+        - CrawlerName: !Ref StandardCrawler
+      Description: This trigger starts the crawler.
       Type: CONDITIONAL
       Predicate:
         Conditions:
         - JobName: !Ref S3ToJsonJobName
           State: SUCCEEDED
           LogicalOperator: EQUALS
+      StartOnCreation: true
+      WorkflowName: !Ref PrimaryWorkflow
+
+  StandardCrawler:
+    Type: AWS::Glue::Crawler
+    Properties:
+      Configuration: '{"Version":1.0,"CrawlerOutput":{"Partitions":{"AddOrUpdateBehavior":"InheritFromTable"}},"Grouping":{"TableGroupingPolicy":"CombineCompatibleSchemas"}}'
+      DatabaseName: !Ref GlueDatabase
+      Name: !Sub ${Namespace}-standard
+      RecrawlPolicy:
+        RecrawlBehavior: CRAWL_EVERYTHING
+      Role: !Ref CrawlerRole
+      SchemaChangePolicy:
+        DeleteBehavior: LOG
+        UpdateBehavior: LOG
+      Targets:
+        CatalogTargets:
+        - DatabaseName: !Ref GlueDatabase
+          Tables:
+          {% for data_type in sceptre_user_data.dataset_schemas.tables.keys() %}
+          - dataset_{{ data_type.lower() }}
+          {% endfor %}
+
+  CrawlerCompleteTrigger:
+    Type: AWS::Glue::Trigger
+    Properties:
+      Name: !Sub "${Namespace}-CrawlerCompleteTrigger"
+      Actions:
+        {% for dataset in datasets if not "HealthKit" in dataset["data_type"] and not "Fitbit" in dataset["data_type"] and not "Google" in dataset["data_type"] and not "Garmin" in dataset["data_type"] %}
+        - JobName: !Sub ${Namespace}-{{ dataset["stackname_prefix"]}}-Job
+          Arguments: {"--glue-table": {{ "{}".format(dataset["table_name"]) }} }
+        {% endfor %}
+      Description: This trigger kicks off every JSON to Parquet job which is not associated with a device and runs after completion of the crawler.
+      Type: CONDITIONAL
+      Predicate:
+        Conditions:
+        - CrawlerName: !Ref StandardCrawler
+          LogicalOperator: EQUALS
+          CrawlState: SUCCEEDED
       StartOnCreation: true
       WorkflowName: !Ref PrimaryWorkflow
 

--- a/tests/test_json_to_parquet/TestFlatDataType_20230512.ndjson
+++ b/tests/test_json_to_parquet/TestFlatDataType_20230512.ndjson
@@ -1,1 +1,1 @@
-{"GlobalKey": "123456789", "export_end_date": "2023-05-12T00:00:00"}
+{"GlobalKey": "123456789", "export_end_date": "2023-05-12T00:00:00", "cohort": "adults_v1"}

--- a/tests/test_json_to_parquet/TestFlatDataType_20230612.ndjson
+++ b/tests/test_json_to_parquet/TestFlatDataType_20230612.ndjson
@@ -1,1 +1,1 @@
-{"GlobalKey": "123456789", "export_end_date": "2023-06-12T00:00:00"}
+{"GlobalKey": "123456789", "export_end_date": "2023-06-12T00:00:00", "cohort": "adults_v1"}

--- a/tests/test_json_to_parquet/TestFlatDataType_Deleted_20230514.ndjson
+++ b/tests/test_json_to_parquet/TestFlatDataType_Deleted_20230514.ndjson
@@ -1,1 +1,1 @@
-{"GlobalKey": "123456789", "export_end_date": "2023-06-14T00:00:00"}
+{"GlobalKey": "123456789", "export_end_date": "2023-06-14T00:00:00", "cohort": "adults_v1"}

--- a/tests/test_json_to_parquet/TestFlatInsertedDateDataType_20230512.ndjson
+++ b/tests/test_json_to_parquet/TestFlatInsertedDateDataType_20230512.ndjson
@@ -1,1 +1,1 @@
-{"GlobalKey": "123456789", "InsertedDate": "2023-05-12T00:00:00"}
+{"GlobalKey": "123456789", "InsertedDate": "2023-05-12T00:00:00", "cohort": "adults_v1"}

--- a/tests/test_json_to_parquet/TestFlatInsertedDateDataType_20230612.ndjson
+++ b/tests/test_json_to_parquet/TestFlatInsertedDateDataType_20230612.ndjson
@@ -1,1 +1,1 @@
-{"GlobalKey": "123456789", "InsertedDate": "2023-06-12T00:00:00"}
+{"GlobalKey": "123456789", "InsertedDate": "2023-06-12T00:00:00", "cohort": "adults_v1"}

--- a/tests/test_json_to_parquet/TestNestedDataType_20230512.ndjson
+++ b/tests/test_json_to_parquet/TestNestedDataType_20230512.ndjson
@@ -1,1 +1,1 @@
-{"GlobalKey": "123456789", "ArrayOfObjectsField": [{"filename": "test.json", "timestamp": "999"}], "ObjectField": {"filename": "test.json", "timestamp": "999"}, "export_end_date": "2023-05-12T00:00:00"}
+{"GlobalKey": "123456789", "ArrayOfObjectsField": [{"filename": "test.json", "timestamp": "999"}], "ObjectField": {"filename": "test.json", "timestamp": "999"}, "export_end_date": "2023-05-12T00:00:00", "cohort": "adults_v1"}

--- a/tests/test_json_to_parquet/TestNestedDataType_20230612.ndjson
+++ b/tests/test_json_to_parquet/TestNestedDataType_20230612.ndjson
@@ -1,1 +1,1 @@
-{"GlobalKey": "123456789", "ArrayOfObjectsField": [{"filename": "test.json", "timestamp": "999"}], "ObjectField": {"filename": "test.json", "timestamp": "999"}, "export_end_date": "2023-06-12T00:00:00"}
+{"GlobalKey": "123456789", "ArrayOfObjectsField": [{"filename": "test.json", "timestamp": "999"}], "ObjectField": {"filename": "test.json", "timestamp": "999"}, "export_end_date": "2023-06-12T00:00:00", "cohort": "adults_v1"}

--- a/tests/test_s3_to_json.py
+++ b/tests/test_s3_to_json.py
@@ -122,6 +122,7 @@ class TestS3ToJsonS3:
         transformed_json = s3_to_json.transform_json(
                 json_obj={},
                 dataset_identifier=sample_metadata["type"],
+                cohort="adults_v1",
                 metadata=sample_metadata
         )
 
@@ -133,6 +134,7 @@ class TestS3ToJsonS3:
             sample_metadata["end_date"].isoformat()
             == transformed_json["export_end_date"]
         )
+        assert transformed_json["cohort"] == "adults_v1"
 
     def test_transform_json_with_subtype(self):
         sample_metadata = {
@@ -144,6 +146,7 @@ class TestS3ToJsonS3:
         transformed_json = s3_to_json.transform_json(
                 json_obj={},
                 dataset_identifier=sample_metadata["type"],
+                cohort="adults_v1",
                 metadata=sample_metadata
         )
 
@@ -167,6 +170,7 @@ class TestS3ToJsonS3:
         transformed_json = s3_to_json.transform_json(
                 json_obj={"Value": json.dumps(transformed_value)},
                 dataset_identifier=sample_metadata["type"],
+                cohort="adults_v1",
                 metadata=sample_metadata
         )
 
@@ -194,6 +198,7 @@ class TestS3ToJsonS3:
                     }
                 },
                 dataset_identifier=sample_metadata["type"],
+                cohort="adults_v1",
                 metadata=sample_metadata
         )
 
@@ -225,6 +230,7 @@ class TestS3ToJsonS3:
                     }
                 },
                 dataset_identifier=sample_metadata["type"],
+                cohort="adults_v1",
                 metadata=sample_metadata
         )
 
@@ -266,6 +272,7 @@ class TestS3ToJsonS3:
         transformed_json = s3_to_json.transform_json(
                 json_obj={"TimeOffsetHeartRateSamples": time_offset_heartrate_samples},
                 dataset_identifier=sample_metadata["type"],
+                cohort="adults_v1",
                 metadata=sample_metadata
         )
 
@@ -322,6 +329,7 @@ class TestS3ToJsonS3:
                     ]
                 },
                 dataset_identifier=sample_metadata["type"],
+                cohort="adults_v1",
                 metadata=sample_metadata
         )
 
@@ -363,6 +371,7 @@ class TestS3ToJsonS3:
                 transformed_block = s3_to_json.transform_block(
                     input_json=input_json,
                     dataset_identifier=sample_metadata["type"],
+                    cohort="adults_v1",
                     metadata=sample_metadata,
                     block_size=2
                 )
@@ -381,6 +390,7 @@ class TestS3ToJsonS3:
                 transformed_block = s3_to_json.transform_block(
                     input_json=input_json,
                     dataset_identifier=sample_metadata["type"],
+                    cohort="adults_v1",
                     metadata=sample_metadata,
                     block_size=2
                 )
@@ -405,6 +415,7 @@ class TestS3ToJsonS3:
                 transformed_block = s3_to_json.transform_block(
                     input_json=input_json,
                     dataset_identifier=sample_metadata["type"],
+                    cohort="adults_v1",
                     metadata=sample_metadata,
                     block_size=10
                 )


### PR DESCRIPTION
- Added `cohort` as a partition in our Glue table schemas.
- This requires us to include `cohort` as a property in our JSON. I also did some light refactoring around `get_part_path` in the S3 to JSON job.
- To add these partitions to our table, we need a Glue crawler. I've added one to crawl every data type.
- Updated test data to reflect the way data is organized in production (e.g., in `adults_v1` and `pediatric_v1` directories). Updated test event generation script so that it does not include these "directories" as individual events.
- Updated tests