### PR TITLE
[ETL-537] Modify lambda event generation script to produce SQS events

### DIFF
--- a/config/develop/namespaced/s3-event-config-lambda.yaml
+++ b/config/develop/namespaced/s3-event-config-lambda.yaml
@@ -6,6 +6,7 @@ template:
 dependencies:
   - develop/namespaced/s3-event-config-lambda-role.yaml
   - develop/namespaced/s3-to-glue-lambda.yaml
+  - develop/namespaced/sqs-queue.yaml
 stack_name: '{{ stack_group_config.namespace }}-lambda-S3EventConfig'
 stack_tags: {{ stack_group_config.default_stack_tags }}
 parameters:

--- a/config/prod/namespaced/s3-event-config-lambda.yaml
+++ b/config/prod/namespaced/s3-event-config-lambda.yaml
@@ -6,6 +6,7 @@ template:
 dependencies:
   - prod/namespaced/s3-event-config-lambda-role.yaml
   - prod/namespaced/s3-to-glue-lambda.yaml
+  - prod/namespaced/sqs-queue.yaml
 stack_name: '{{ stack_group_config.namespace }}-lambda-S3EventConfig'
 stack_tags: {{ stack_group_config.default_stack_tags }}
 parameters:


### PR DESCRIPTION
Rather than S3 events, we will send an SQS event wrapping one or more S3 events to our lambda.

Needs to be rebased on the work happening in #77 before merging.