### PR TITLE
[ETL-538] Add dead letter queue for our SQS queue

### DIFF
--- a/templates/sqs-queue.yaml
+++ b/templates/sqs-queue.yaml
@@ -36,6 +36,9 @@ Resources:
       QueueName: !Sub '${AWS::StackName}-Queue'
       ReceiveMessageWaitTimeSeconds: !Ref ReceiveMessageWaitTimeSeconds
       VisibilityTimeout: !Ref VisibilityTimeout
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt DeadLetterQueue.Arn
+        maxReceiveCount: 3
 
   PrimaryQueuePolicy:
     Type: AWS::SQS::QueuePolicy
@@ -56,6 +59,17 @@ Resources:
               "aws:SourceArn": !Ref S3SourceBucketArn
       Queues:
       - !Ref PrimaryQueue
+
+  DeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      DelaySeconds: 0
+      MessageRetentionPeriod: 1209600
+      QueueName: !Sub '${AWS::StackName}-DeadLetterQueue'
+      ReceiveMessageWaitTimeSeconds: !Ref ReceiveMessageWaitTimeSeconds
+      RedriveAllowPolicy:
+        redrivePermission: allowAll
+      VisibilityTimeout: !Ref VisibilityTimeout
 
 Outputs:
 


### PR DESCRIPTION
The behavior is as follows:

1. If Lambda raises an exception, the message will be sent back to the primary SQS queue up to 3 times before sending that message to the dead letter queue
2. Once the message is in the DLQ, it will be available for up to 2 weeks (the maximum allowed value) until we do a manual redrive of the message back to the primary SQS queue. If the message hasn't been processed after 2 weeks it disappears and will need to be added back to the primary queue either manually (more likely we would generate our own SQS event and send it directly to the Lambda) or by depositing the data in S3 again.

The DLQ doesn't need its own queue policy. It has permissions to receive and redrive messages to the primary queue on account of the primary queue's `RedrivePolicy`.