### PR TITLE
[ETL-553] Allow merging of notification configs

### DIFF
--- a/src/lambda_function/s3_event_config/app.py
+++ b/src/lambda_function/s3_event_config/app.py
@@ -63,8 +63,14 @@ def add_notification(
         bucket (str): bucket name of the s3 bucket to add the config to
         bucket_key_prefix (str): bucket key prefix for where to look for s3 object notifications
     """
-    existing_bucket_notification_configuration = s3_client.get_bucket_notification_configuration(Bucket=bucket)
-    existing_notification_config_for_type = existing_bucket_notification_configuration.get(f"{destination_type}Configurations", {})
+    existing_bucket_notification_configuration = (
+        s3_client.get_bucket_notification_configuration(Bucket=bucket)
+    )
+    existing_notification_config_for_type = (
+        existing_bucket_notification_configuration.get(
+            f"{destination_type}Configurations", {}
+        )
+    )
 
     new_notification_config = {
         f"{destination_type}Configurations": [
@@ -83,8 +89,15 @@ def add_notification(
     }
 
     # If the configuration we want to add isn't there or is different then create a new that contains the new value along with any previous data.
-    if not existing_notification_config_for_type or json.dumps(existing_notification_config_for_type, sort_keys=True) != json.dumps(new_notification_config, sort_keys=True):
-        merged_config = {**existing_bucket_notification_configuration, **new_notification_config}
+    if not existing_notification_config_for_type or json.dumps(
+        existing_notification_config_for_type, sort_keys=True
+    ) != json.dumps(
+        new_notification_config[f"{destination_type}Configurations"], sort_keys=True
+    ):
+        merged_config = {
+            **existing_bucket_notification_configuration,
+            **new_notification_config,
+        }
 
         s3_client.put_bucket_notification_configuration(
             Bucket=bucket,

--- a/tests/test_json_to_parquet.py
+++ b/tests/test_json_to_parquet.py
@@ -340,7 +340,7 @@ def glue_test_data(glue_flat_table_location, glue_nested_table_location,
 @pytest.fixture(scope="class")
 def glue_crawler_role(namespace):
     iam_client = boto3.client("iam")
-    role_name=f"{namespace}-pytest-crawler-role"
+    role_name=f"{namespace}-pytest-crawler-role"[:60]
     glue_service_policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
     s3_read_policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
     glue_crawler_role = iam_client.create_role(

--- a/tests/test_s3_event_config_lambda.py
+++ b/tests/test_s3_event_config_lambda.py
@@ -48,13 +48,18 @@ def test_that_add_notification_adds_expected_settings_for_lambda(
     s3, mock_lambda_function
 ):
     s3.create_bucket(Bucket="some_bucket")
-    set_config = app.add_notification(
+    with mock.patch.object(
         s3,
-        "LambdaFunction",
-        mock_lambda_function["Configuration"]["FunctionArn"],
-        "some_bucket",
-        "test_folder",
-    )
+        "get_bucket_notification_configuration",
+        return_value={},
+    ):
+        app.add_notification(
+            s3,
+            "LambdaFunction",
+            mock_lambda_function["Configuration"]["FunctionArn"],
+            "some_bucket",
+            "test_folder",
+        )
     get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
     assert (
         get_config["LambdaFunctionConfigurations"][0]["LambdaFunctionArn"]
@@ -71,13 +76,18 @@ def test_that_add_notification_adds_expected_settings_for_lambda(
 @mock_s3
 def test_that_delete_notification_is_successful_for_lambda(s3, mock_lambda_function):
     s3.create_bucket(Bucket="some_bucket")
-    app.add_notification(
+    with mock.patch.object(
         s3,
-        "LambdaFunction",
-        mock_lambda_function["Configuration"]["FunctionArn"],
-        "some_bucket",
-        "test_folder",
-    )
+        "get_bucket_notification_configuration",
+        return_value={},
+    ):
+        app.add_notification(
+            s3,
+            "LambdaFunction",
+            mock_lambda_function["Configuration"]["FunctionArn"],
+            "some_bucket",
+            "test_folder",
+        )
     app.delete_notification(s3, "some_bucket")
     get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
     assert "LambdaFunctionConfigurations" not in get_config
@@ -86,13 +96,18 @@ def test_that_delete_notification_is_successful_for_lambda(s3, mock_lambda_funct
 @mock_s3
 def test_that_add_notification_adds_expected_settings_for_sqs(s3, mock_sqs_queue):
     s3.create_bucket(Bucket="some_bucket")
-    set_config = app.add_notification(
+    with mock.patch.object(
         s3,
-        "Queue",
-        mock_sqs_queue["Attributes"]["QueueArn"],
-        "some_bucket",
-        "test_folder",
-    )
+        "get_bucket_notification_configuration",
+        return_value={},
+    ):
+        app.add_notification(
+            s3,
+            "Queue",
+            mock_sqs_queue["Attributes"]["QueueArn"],
+            "some_bucket",
+            "test_folder",
+        )
     get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
     assert (
         get_config["QueueConfigurations"][0]["QueueArn"]
@@ -107,13 +122,18 @@ def test_that_add_notification_adds_expected_settings_for_sqs(s3, mock_sqs_queue
 @mock_s3
 def test_that_delete_notification_is_successful_for_sqs(s3, mock_sqs_queue):
     s3.create_bucket(Bucket="some_bucket")
-    app.add_notification(
+    with mock.patch.object(
         s3,
-        "Queue",
-        mock_sqs_queue["Attributes"]["QueueArn"],
-        "some_bucket",
-        "test_folder",
-    )
+        "get_bucket_notification_configuration",
+        return_value={},
+    ):
+        app.add_notification(
+            s3,
+            "Queue",
+            mock_sqs_queue["Attributes"]["QueueArn"],
+            "some_bucket",
+            "test_folder",
+        )
     app.delete_notification(s3, "some_bucket")
     get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
     assert "QueueConfigurations" not in get_config
@@ -147,7 +167,7 @@ def test_add_notification_does_nothing_if_notification_already_exists(
                 }
             ]
         },
-    ):
+    ), mock.patch.object(s3, "put_bucket_notification_configuration") as put_config:
         # WHEN I add the existing matching `LambdaFunction` configuration
         app.add_notification(
             s3,
@@ -161,7 +181,7 @@ def test_add_notification_does_nothing_if_notification_already_exists(
     get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
 
     # THEN I expect nothing to have been saved in our mocked environment
-    assert get_config.get("LambdaFunctionConfigurations", None) is None
+    assert not put_config.called
 
 
 @mock_s3
@@ -192,7 +212,7 @@ def test_add_notification_does_nothing_if_notification_already_exists_even_in_di
                 }
             ]
         },
-    ):
+    ), mock.patch.object(s3, "put_bucket_notification_configuration") as put_config:
         # WHEN I add the existing matching `LambdaFunction` configuration
         app.add_notification(
             s3,
@@ -206,7 +226,7 @@ def test_add_notification_does_nothing_if_notification_already_exists_even_in_di
     get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
 
     # THEN I expect nothing to have been saved in our mocked environment
-    assert get_config.get("LambdaFunctionConfigurations", None) is None
+    assert not put_config.called
 
 
 @mock_s3

--- a/tests/test_s3_event_config_lambda.py
+++ b/tests/test_s3_event_config_lambda.py
@@ -1,3 +1,4 @@
+from unittest import mock
 import zipfile
 import io
 import boto3
@@ -43,7 +44,9 @@ def mock_sqs_queue(mock_aws_credentials):
 
 
 @mock_s3
-def test_that_add_notification_adds_expected_settings_for_lambda(s3, mock_lambda_function):
+def test_that_add_notification_adds_expected_settings_for_lambda(
+    s3, mock_lambda_function
+):
     s3.create_bucket(Bucket="some_bucket")
     set_config = app.add_notification(
         s3,
@@ -86,18 +89,16 @@ def test_that_add_notification_adds_expected_settings_for_sqs(s3, mock_sqs_queue
     set_config = app.add_notification(
         s3,
         "Queue",
-        mock_sqs_queue['Attributes']['QueueArn'],
+        mock_sqs_queue["Attributes"]["QueueArn"],
         "some_bucket",
         "test_folder",
     )
     get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
     assert (
         get_config["QueueConfigurations"][0]["QueueArn"]
-        == mock_sqs_queue['Attributes']['QueueArn']
+        == mock_sqs_queue["Attributes"]["QueueArn"]
     )
-    assert get_config["QueueConfigurations"][0]["Events"] == [
-        "s3:ObjectCreated:*"
-    ]
+    assert get_config["QueueConfigurations"][0]["Events"] == ["s3:ObjectCreated:*"]
     assert get_config["QueueConfigurations"][0]["Filter"] == {
         "Key": {"FilterRules": [{"Name": "prefix", "Value": "test_folder/"}]}
     }
@@ -109,10 +110,210 @@ def test_that_delete_notification_is_successful_for_sqs(s3, mock_sqs_queue):
     app.add_notification(
         s3,
         "Queue",
-        mock_sqs_queue['Attributes']['QueueArn'],
+        mock_sqs_queue["Attributes"]["QueueArn"],
         "some_bucket",
         "test_folder",
     )
     app.delete_notification(s3, "some_bucket")
     get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
     assert "QueueConfigurations" not in get_config
+
+
+@mock_s3
+def test_add_notification_does_nothing_if_notification_already_exists(
+    s3, mock_lambda_function
+):
+    # GIVEN an S3 bucket
+    s3.create_bucket(Bucket="some_bucket")
+
+    # AND the bucket has an existing `LambdaFunctionConfigurations` that matches the one we will add
+    with mock.patch.object(
+        s3,
+        "get_bucket_notification_configuration",
+        return_value={
+            f"LambdaFunctionConfigurations": [
+                {
+                    f"LambdaFunctionArn": mock_lambda_function["Configuration"][
+                        "FunctionArn"
+                    ],
+                    "Events": ["s3:ObjectCreated:*"],
+                    "Filter": {
+                        "Key": {
+                            "FilterRules": [
+                                {"Name": "prefix", "Value": f"test_folder/"}
+                            ]
+                        }
+                    },
+                }
+            ]
+        },
+    ):
+        # WHEN I add the existing matching `LambdaFunction` configuration
+        app.add_notification(
+            s3,
+            "LambdaFunction",
+            mock_lambda_function["Configuration"]["FunctionArn"],
+            "some_bucket",
+            "test_folder",
+        )
+
+    # AND I get the notification configuration
+    get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
+
+    # THEN I expect nothing to have been saved in our mocked environment
+    assert get_config.get("LambdaFunctionConfigurations", None) is None
+
+
+@mock_s3
+def test_add_notification_does_nothing_if_notification_already_exists_even_in_different_dict_order(
+    s3, mock_lambda_function
+):
+    # GIVEN an S3 bucket
+    s3.create_bucket(Bucket="some_bucket")
+
+    # AND the bucket has an existing `LambdaFunctionConfigurations` that matches content of the one we will add - But differs in order
+    with mock.patch.object(
+        s3,
+        "get_bucket_notification_configuration",
+        return_value={
+            f"LambdaFunctionConfigurations": [
+                {
+                    "Filter": {
+                        "Key": {
+                            "FilterRules": [
+                                {"Name": "prefix", "Value": f"test_folder/"}
+                            ]
+                        }
+                    },
+                    "Events": ["s3:ObjectCreated:*"],
+                    f"LambdaFunctionArn": mock_lambda_function["Configuration"][
+                        "FunctionArn"
+                    ],
+                }
+            ]
+        },
+    ):
+        # WHEN I add the existing matching `LambdaFunction` configuration
+        app.add_notification(
+            s3,
+            "LambdaFunction",
+            mock_lambda_function["Configuration"]["FunctionArn"],
+            "some_bucket",
+            "test_folder",
+        )
+
+    # AND I get the notification configuration
+    get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
+
+    # THEN I expect nothing to have been saved in our mocked environment
+    assert get_config.get("LambdaFunctionConfigurations", None) is None
+
+
+@mock_s3
+def test_add_notification_adds_config_if_requested_notification_does_not_exist(
+    s3, mock_lambda_function, mock_sqs_queue
+):
+    # GIVEN an S3 bucket
+    s3.create_bucket(Bucket="some_bucket")
+
+    # AND the bucket has an existing `QueueConfigurations`
+    with mock.patch.object(
+        s3,
+        "get_bucket_notification_configuration",
+        return_value={
+            f"QueueConfigurations": [
+                {
+                    "Id": "123",
+                    "QueueArn": mock_sqs_queue["Attributes"]["QueueArn"],
+                    "Events": ["s3:ObjectCreated:*"],
+                    "Filter": {
+                        "Key": {
+                            "FilterRules": [
+                                {"Name": "prefix", "Value": f"test_folder/"}
+                            ]
+                        }
+                    },
+                }
+            ]
+        },
+    ):
+        # WHEN I add a new `LambdaFunction` configuration
+        app.add_notification(
+            s3,
+            "LambdaFunction",
+            mock_lambda_function["Configuration"]["FunctionArn"],
+            "some_bucket",
+            "test_folder",
+        )
+
+    # AND I get the notification configuration
+    get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
+
+    # THEN I expect to see a new `LambdaFunction` configuration
+    assert (
+        get_config["LambdaFunctionConfigurations"][0]["LambdaFunctionArn"]
+        == mock_lambda_function["Configuration"]["FunctionArn"]
+    )
+    assert get_config["LambdaFunctionConfigurations"][0]["Events"] == [
+        "s3:ObjectCreated:*"
+    ]
+    assert get_config["LambdaFunctionConfigurations"][0]["Filter"] == {
+        "Key": {"FilterRules": [{"Name": "prefix", "Value": "test_folder/"}]}
+    }
+
+    # AND I expect the `QueueConfigurations` to be unchanged
+    assert (
+        get_config["QueueConfigurations"][0]["QueueArn"]
+        == mock_sqs_queue["Attributes"]["QueueArn"]
+    )
+    assert get_config["QueueConfigurations"][0]["Events"] == ["s3:ObjectCreated:*"]
+    assert get_config["QueueConfigurations"][0]["Filter"] == {
+        "Key": {"FilterRules": [{"Name": "prefix", "Value": "test_folder/"}]}
+    }
+
+
+@mock_s3
+def test_add_notification_adds_config_if_existing_config_does_not_match(
+    s3, mock_lambda_function
+):
+    # GIVEN an S3 bucket
+    s3.create_bucket(Bucket="some_bucket")
+
+    # AND the bucket has an existing `LambdaFunctionConfigurations` that does not match the one we are adding
+    with mock.patch.object(
+        s3,
+        "get_bucket_notification_configuration",
+        return_value={
+            f"LambdaFunctionConfigurations": [
+                {
+                    f"SomeOtherArn": mock_lambda_function["Configuration"][
+                        "FunctionArn"
+                    ],
+                    "Events": ["s3:SomeOtherS3Event:*"],
+                }
+            ]
+        },
+    ):
+        # WHEN I add the `LambdaFunction` configuration
+        app.add_notification(
+            s3,
+            "LambdaFunction",
+            mock_lambda_function["Configuration"]["FunctionArn"],
+            "some_bucket",
+            "test_folder",
+        )
+
+    # AND I get the notification configuration
+    get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
+
+    # THEN I expect to see the updated `LambdaFunction` configuration
+    assert (
+        get_config["LambdaFunctionConfigurations"][0]["LambdaFunctionArn"]
+        == mock_lambda_function["Configuration"]["FunctionArn"]
+    )
+    assert get_config["LambdaFunctionConfigurations"][0]["Events"] == [
+        "s3:ObjectCreated:*"
+    ]
+    assert get_config["LambdaFunctionConfigurations"][0]["Filter"] == {
+        "Key": {"FilterRules": [{"Name": "prefix", "Value": "test_folder/"}]}
+    }


### PR DESCRIPTION
**Problem:**

1. When running lamdba_function `s3_event_config` new notifications could not be added to an S3 bucket, instead the notification configuration was always overwritten.
2. When deleting a NotificationConfiguration for a specific type ALL notification types were deleted.

**Solution:**
A) Adding notifications:
            1) If a bucket has no `NotificationConfiguration` then create the config
            2) If a bucket has a `NotificationConfiguration` but no matching "{destination_type}Configurations" then merge and add the config
            3) If a bucket has a `NotificationConfiguration` and a matching "{destination_type}Configurations":
                3a) If the config is the same then do nothing - ordering of the dict does not matter
                3b) If the config is different then overwrite the matching "{destination_type}Configurations"
B) Deleting notifications - Only deleting the specific notificationConfiguration that matches the `"{destination_type}Configurations"`

**Testing:**
I wrote unit tests for all paths