### PR TITLE
[ETL-553] Allow merging of notification configs

### DIFF
--- a/src/lambda_function/s3_event_config/app.py
+++ b/src/lambda_function/s3_event_config/app.py
@@ -4,11 +4,14 @@ puts a s3 event notification configuration for the S3 to Glue lambda in the
 input data S3 bucket set by the environment variable `S3_SOURCE_BUCKET_NAME`.
 
 This Lambda app also has the option of deleting the notification configuration
-from an S3 bucket
+from an S3 bucket.
+
+Only certain notification configurations work. Only `QueueConfigurations` are expected.
 """
 import os
 import json
 import logging
+import typing
 
 import boto3
 
@@ -44,25 +47,111 @@ def lambda_handler(event, context):
         raise KeyError(err_msg)
 
 
+def get_existing_bucket_notification_configuration_and_type(
+    s3_client: boto3.client, bucket: str, destination_type: str
+) -> typing.Tuple[dict, list]:
+    """
+    Gets the existing bucket notification configuration and the existing notification
+    configurations for a specific destination type.
+
+    Arguments:
+        s3_client (boto3.client) : s3 client to use for s3 event config
+        bucket (str): bucket name of the s3 bucket to delete the config in
+        destination_type (str): String name of the destination type for the configuration
+
+    Returns:
+        Tuple: A bucket notifiction configuration,
+            and the notification configurations for a specific destination type
+    """
+    existing_bucket_notification_configuration = (
+        s3_client.get_bucket_notification_configuration(Bucket=bucket)
+    )
+
+    # Remove ResponseMetadata because we don't want to persist it
+    existing_bucket_notification_configuration.pop("ResponseMetadata", None)
+
+    existing_notification_configurations_for_type = (
+        existing_bucket_notification_configuration.get(
+            f"{destination_type}Configurations", []
+        )
+    )
+
+    # Initialize this with an empty list to have consistent handling if it's present
+    # or missing.
+    if not existing_notification_configurations_for_type:
+        existing_bucket_notification_configuration[
+            f"{destination_type}Configurations"
+        ] = []
+
+    return (
+        existing_bucket_notification_configuration,
+        existing_notification_configurations_for_type,
+    )
+
+
+def get_matching_notification_configuration(
+    destination_type_arn: str,
+    existing_notification_configurations_for_type: list,
+    destination_arn: str,
+) -> typing.Union[tuple[int, dict], tuple[None, None]]:
+    """
+    Search through the list of existing notifications and find the one that has a key of
+    `destination_type_arn` and a value of `destination_arn`.
+
+    Arguments:
+        destination_type_arn (str): Key value for the destination type arn
+        existing_notification_configurations_for_type (list): The existing notification configs
+        destination_arn (str): Arn of the destination's s3 event config
+
+    Returns:
+        tuple: The index of the matching notification configuration and the matching
+            notification configuration or None, None if no match is found
+    """
+    for index, existing_notification_configuration_for_type in enumerate(
+        existing_notification_configurations_for_type
+    ):
+        if (
+            destination_type_arn in existing_notification_configuration_for_type
+            and existing_notification_configuration_for_type[destination_type_arn]
+            == destination_arn
+        ):
+            return index, existing_notification_configuration_for_type
+    return None, None
+
+
+def create_formatted_message(
+    bucket: str, destination_type: str, destination_arn: str
+) -> str:
+    """Creates a formatted message for logging purposes.
+
+    Arguments:
+        bucket (str): bucket name of the s3 bucket
+        destination_type (str): String name of the destination type for the configuration
+        destination_arn (str): Arn of the destination's s3 event config
+
+    Returns:
+        str: A formatted message
+    """
+    return f"Bucket: {bucket}, DestinationType: {destination_type}, DestinationArn: {destination_arn}"
+
+
 def add_notification(
     s3_client: boto3.client,
     destination_type: str,
     destination_arn: str,
     bucket: str,
     bucket_key_prefix: str,
-):
+) -> None:
     """Adds the S3 notification configuration to an existing bucket.
 
         Use cases:
             1) If a bucket has no `NotificationConfiguration` then create the config
             2) If a bucket has a `NotificationConfiguration` but no matching
-                "{destination_type}Configurations" then merge and add the config
+                "{destination_arn}" for the "{destination_type}" then add the config
             3) If a bucket has a `NotificationConfiguration` and a matching
-                                                    "{destination_type}Configurations":
-                3a) If the config is the same then do nothing - ordering of the dict
-                                                                        does not matter
-                3b) If the config is different then overwrite the matching
-                                                    "{destination_type}Configurations"
+                                    "{destination_arn}" for the "{destination_type}":
+                3a) If the config is the same then do nothing
+                3b) If the config is different then overwrite the matching config
 
     Args:
         s3_client (boto3.client) : s3 client to use for s3 event config
@@ -71,59 +160,70 @@ def add_notification(
         bucket (str): bucket name of the s3 bucket to add the config to
         bucket_key_prefix (str): bucket key prefix for where to look for s3 object notifications
     """
-    existing_bucket_notification_configuration = (
-        s3_client.get_bucket_notification_configuration(Bucket=bucket)
-    )
-    existing_bucket_notification_configuration.pop("ResponseMetadata", None)
-    existing_notification_config_for_type = (
-        existing_bucket_notification_configuration.get(
-            f"{destination_type}Configurations", {}
-        )
-    )
-
-    new_notification_config = {
-        f"{destination_type}Configurations": [
-            {
-                f"{destination_type}Arn": destination_arn,
-                "Events": ["s3:ObjectCreated:*"],
-                "Filter": {
-                    "Key": {
-                        "FilterRules": [
-                            {"Name": "prefix", "Value": f"{bucket_key_prefix}/"}
-                        ]
-                    }
-                },
+    update_required = False
+    destination_type_arn = f"{destination_type}Arn"
+    new_notification_configuration = {
+        destination_type_arn: destination_arn,
+        "Events": ["s3:ObjectCreated:*"],
+        "Filter": {
+            "Key": {
+                "FilterRules": [{"Name": "prefix", "Value": f"{bucket_key_prefix}/"}]
             }
-        ]
+        },
     }
 
-    # If the configuration we want to add isn't there
-    # or is different from what we want to update it with
-    if not existing_notification_config_for_type or json.dumps(
-        existing_notification_config_for_type, sort_keys=True
-    ) != json.dumps(
-        new_notification_config[f"{destination_type}Configurations"], sort_keys=True
-    ):
-        merged_config = {
-            **existing_bucket_notification_configuration,
-            **new_notification_config,
-        }
+    (
+        existing_bucket_notification_configuration,
+        existing_notification_configurations_for_type,
+    ) = get_existing_bucket_notification_configuration_and_type(
+        s3_client, bucket, destination_type
+    )
 
+    (
+        index_of_matching_arn,
+        matching_notification_configuration,
+    ) = get_matching_notification_configuration(
+        destination_type_arn,
+        existing_notification_configurations_for_type,
+        destination_arn,
+    )
+
+    if index_of_matching_arn is not None:
+        if json.dumps(
+            matching_notification_configuration, sort_keys=True
+        ) != json.dumps(new_notification_configuration, sort_keys=True):
+            existing_notification_configurations_for_type[
+                index_of_matching_arn
+            ] = new_notification_configuration
+            update_required = True
+    else:
+        existing_notification_configurations_for_type.append(
+            new_notification_configuration
+        )
+        update_required = True
+
+    if update_required:
+        existing_bucket_notification_configuration[
+            f"{destination_type}Configurations"
+        ] = existing_notification_configurations_for_type
         s3_client.put_bucket_notification_configuration(
             Bucket=bucket,
-            NotificationConfiguration=merged_config,
+            NotificationConfiguration=existing_bucket_notification_configuration,
         )
         logger.info(
-            f"Put request completed to add a \
-                NotificationConfiguration for `{destination_type}Configurations`."
+            f"Put request completed to add a NotificationConfiguration for"
+            + create_formatted_message(bucket, destination_type, destination_arn)
         )
     else:
         logger.info(
-            f"Put not required as an existing NotificationConfiguration \
-                for `{destination_type}Configurations` already exists."
+            f"Put not required as an existing NotificationConfiguration already exists for"
+            + create_formatted_message(bucket, destination_type, destination_arn)
         )
 
-def delete_notification(s3_client: boto3.client, bucket: str, destination_type: str):
+
+def delete_notification(
+    s3_client: boto3.client, bucket: str, destination_type: str, destination_arn: str
+) -> None:
     """Deletes the S3 notification configuration from an existing bucket for a specific destination type.
 
     Args:
@@ -131,28 +231,46 @@ def delete_notification(s3_client: boto3.client, bucket: str, destination_type: 
         bucket (str): bucket name of the s3 bucket to delete the config in
         destination_type (str): String name of the destination type for the configuration
     """
-    existing_bucket_notification_configuration = (
-        s3_client.get_bucket_notification_configuration(Bucket=bucket)
-    )
-    existing_bucket_notification_configuration.pop("ResponseMetadata", None)
-    configuration_name = f"{destination_type}Configurations"
+    destination_type_arn = f"{destination_type}Arn"
 
-    existing_notification_config_for_type = (
-        existing_bucket_notification_configuration.get(configuration_name, {})
+    (
+        existing_bucket_notification_configuration,
+        existing_notification_configurations_for_type,
+    ) = get_existing_bucket_notification_configuration_and_type(
+        s3_client, bucket, destination_type
     )
 
-    if existing_notification_config_for_type:
-        del existing_bucket_notification_configuration[configuration_name]
+    (
+        index_of_matching_arn,
+        matching_notification_confiugration,
+    ) = get_matching_notification_configuration(
+        destination_type_arn,
+        existing_notification_configurations_for_type,
+        destination_arn,
+    )
+
+    if index_of_matching_arn is not None:
+        del existing_notification_configurations_for_type[index_of_matching_arn]
+
+        if existing_notification_configurations_for_type:
+            existing_bucket_notification_configuration[
+                f"{destination_type}Configurations"
+            ] = existing_notification_configurations_for_type
+        else:
+            del existing_bucket_notification_configuration[
+                f"{destination_type}Configurations"
+            ]
+
         s3_client.put_bucket_notification_configuration(
             Bucket=bucket,
             NotificationConfiguration=existing_bucket_notification_configuration,
         )
         logger.info(
-            f"Delete request completed to remove a \
-                NotificationConfiguration for `{destination_type}Configurations`."
+            f"Delete request completed to remove a NotificationConfiguration for"
+            + create_formatted_message(bucket, destination_type, destination_arn)
         )
     else:
         logger.info(
-            f"Delete not required as no \
-                NotificationConfiguration exists for `{destination_type}Configurations`."
+            f"Delete not required as no NotificationConfiguration exists for"
+            + create_formatted_message(bucket, destination_type, destination_arn)
         )

--- a/src/lambda_function/s3_event_config/app.py
+++ b/src/lambda_function/s3_event_config/app.py
@@ -30,6 +30,7 @@ def lambda_handler(event, context):
             s3,
             bucket=os.environ["S3_SOURCE_BUCKET_NAME"],
             destination_type=os.environ["S3_TO_GLUE_DESTINATION_TYPE"],
+            destination_arn=os.environ["S3_TO_GLUE_DESTINATION_ARN"]
         )
         logger.info("Sending response to custom resource after Delete")
     elif event["RequestType"] in ["Update", "Create"]:

--- a/src/lambda_function/s3_event_config/app.py
+++ b/src/lambda_function/s3_event_config/app.py
@@ -55,10 +55,14 @@ def add_notification(
 
         Use cases:
             1) If a bucket has no `NotificationConfiguration` then create the config
-            2) If a bucket has a `NotificationConfiguration` but no matching "{destination_type}Configurations" then merge and add the config
-            3) If a bucket has a `NotificationConfiguration` and a matching "{destination_type}Configurations":
-                3a) If the config is the same then do nothing - ordering of the dict does not matter
-                3b) If the config is different then overwrite the matching "{destination_type}Configurations"
+            2) If a bucket has a `NotificationConfiguration` but no matching 
+                "{destination_type}Configurations" then merge and add the config
+            3) If a bucket has a `NotificationConfiguration` and a matching 
+                                                    "{destination_type}Configurations":
+                3a) If the config is the same then do nothing - ordering of the dict 
+                                                                        does not matter
+                3b) If the config is different then overwrite the matching 
+                                                    "{destination_type}Configurations"
 
     Args:
         s3_client (boto3.client) : s3 client to use for s3 event config
@@ -70,6 +74,7 @@ def add_notification(
     existing_bucket_notification_configuration = (
         s3_client.get_bucket_notification_configuration(Bucket=bucket)
     )
+    existing_bucket_notification_configuration.pop("ResponseMetadata", None)
     existing_notification_config_for_type = (
         existing_bucket_notification_configuration.get(
             f"{destination_type}Configurations", {}
@@ -92,7 +97,8 @@ def add_notification(
         ]
     }
 
-    # If the configuration we want to add isn't there or is different then create a new that contains the new value along with any previous data.
+    # If the configuration we want to add isn't there 
+    # or is different from what we want to update it with
     if not existing_notification_config_for_type or json.dumps(
         existing_notification_config_for_type, sort_keys=True
     ) != json.dumps(
@@ -108,13 +114,14 @@ def add_notification(
             NotificationConfiguration=merged_config,
         )
         logger.info(
-            f"Put request completed to add a NotificationConfiguration for `{destination_type}Configurations`."
+            f"Put request completed to add a \
+                NotificationConfiguration for `{destination_type}Configurations`."
         )
     else:
         logger.info(
-            f"Put not required as an existing NotificationConfiguration for `{destination_type}Configurations` already exists."
+            f"Put not required as an existing NotificationConfiguration \
+                for `{destination_type}Configurations` already exists."
         )
-
 
 def delete_notification(s3_client: boto3.client, bucket: str, destination_type: str):
     """Deletes the S3 notification configuration from an existing bucket for a specific destination type.
@@ -127,7 +134,7 @@ def delete_notification(s3_client: boto3.client, bucket: str, destination_type: 
     existing_bucket_notification_configuration = (
         s3_client.get_bucket_notification_configuration(Bucket=bucket)
     )
-
+    existing_bucket_notification_configuration.pop("ResponseMetadata", None)
     configuration_name = f"{destination_type}Configurations"
 
     existing_notification_config_for_type = (
@@ -141,9 +148,11 @@ def delete_notification(s3_client: boto3.client, bucket: str, destination_type: 
             NotificationConfiguration=existing_bucket_notification_configuration,
         )
         logger.info(
-            f"Delete request completed to remove a NotificationConfiguration for `{destination_type}Configurations`."
+            f"Delete request completed to remove a \
+                NotificationConfiguration for `{destination_type}Configurations`."
         )
     else:
         logger.info(
-            f"Delete not required as no NotificationConfiguration exists for `{destination_type}Configurations`."
+            f"Delete not required as no \
+                NotificationConfiguration exists for `{destination_type}Configurations`."
         )

--- a/src/lambda_function/s3_event_config/app.py
+++ b/src/lambda_function/s3_event_config/app.py
@@ -63,8 +63,14 @@ def add_notification(
         bucket (str): bucket name of the s3 bucket to add the config to
         bucket_key_prefix (str): bucket key prefix for where to look for s3 object notifications
     """
-    existing_bucket_notification_configuration = s3_client.get_bucket_notification_configuration(Bucket=bucket)
-    existing_notification_config_for_type = existing_bucket_notification_configuration.get(f"{destination_type}Configurations", {})
+    existing_bucket_notification_configuration = (
+        s3_client.get_bucket_notification_configuration(Bucket=bucket)
+    )
+    existing_notification_config_for_type = (
+        existing_bucket_notification_configuration.get(
+            f"{destination_type}Configurations", {}
+        )
+    )
 
     new_notification_config = {
         f"{destination_type}Configurations": [
@@ -83,8 +89,15 @@ def add_notification(
     }
 
     # If the configuration we want to add isn't there or is different then create a new that contains the new value along with any previous data.
-    if not existing_notification_config_for_type or json.dumps(existing_notification_config_for_type, sort_keys=True) != json.dumps(new_notification_config, sort_keys=True):
-        merged_config = {**existing_bucket_notification_configuration, **new_notification_config}
+    if not existing_notification_config_for_type or json.dumps(
+        existing_notification_config_for_type, sort_keys=True
+    ) != json.dumps(
+        new_notification_config[f"{destination_type}Configurations"], sort_keys=True
+    ):
+        merged_config = {
+            **existing_bucket_notification_configuration,
+            **new_notification_config,
+        }
 
         s3_client.put_bucket_notification_configuration(
             Bucket=bucket,

--- a/src/lambda_function/s3_event_config/app.py
+++ b/src/lambda_function/s3_event_config/app.py
@@ -55,13 +55,13 @@ def add_notification(
 
         Use cases:
             1) If a bucket has no `NotificationConfiguration` then create the config
-            2) If a bucket has a `NotificationConfiguration` but no matching 
+            2) If a bucket has a `NotificationConfiguration` but no matching
                 "{destination_type}Configurations" then merge and add the config
-            3) If a bucket has a `NotificationConfiguration` and a matching 
+            3) If a bucket has a `NotificationConfiguration` and a matching
                                                     "{destination_type}Configurations":
-                3a) If the config is the same then do nothing - ordering of the dict 
+                3a) If the config is the same then do nothing - ordering of the dict
                                                                         does not matter
-                3b) If the config is different then overwrite the matching 
+                3b) If the config is different then overwrite the matching
                                                     "{destination_type}Configurations"
 
     Args:
@@ -97,7 +97,7 @@ def add_notification(
         ]
     }
 
-    # If the configuration we want to add isn't there 
+    # If the configuration we want to add isn't there
     # or is different from what we want to update it with
     if not existing_notification_config_for_type or json.dumps(
         existing_notification_config_for_type, sort_keys=True

--- a/tests/test_json_to_parquet.py
+++ b/tests/test_json_to_parquet.py
@@ -340,7 +340,7 @@ def glue_test_data(glue_flat_table_location, glue_nested_table_location,
 @pytest.fixture(scope="class")
 def glue_crawler_role(namespace):
     iam_client = boto3.client("iam")
-    role_name=f"{namespace}-pytest-crawler-role"[:60]
+    role_name=f"{namespace}-pytest-crawler-role"
     glue_service_policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
     s3_read_policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
     glue_crawler_role = iam_client.create_role(

--- a/tests/test_json_to_parquet.py
+++ b/tests/test_json_to_parquet.py
@@ -340,7 +340,7 @@ def glue_test_data(glue_flat_table_location, glue_nested_table_location,
 @pytest.fixture(scope="class")
 def glue_crawler_role(namespace):
     iam_client = boto3.client("iam")
-    role_name=f"{namespace}-pytest-crawler-role"
+    role_name=f"{namespace}-pytest-crawler-role"[:60]
     glue_service_policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
     s3_read_policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
     glue_crawler_role = iam_client.create_role(

--- a/tests/test_s3_event_config_lambda.py
+++ b/tests/test_s3_event_config_lambda.py
@@ -343,6 +343,7 @@ def test_add_notification_adds_config_if_existing_config_does_not_match(
     assert get_config["LambdaFunctionConfigurations"][0]["Events"] == [
         "s3:ObjectCreated:*"
     ]
+
     assert get_config["LambdaFunctionConfigurations"][0]["Filter"] == {
         "Key": {"FilterRules": [{"Name": "prefix", "Value": "test_folder/"}]}
     }

--- a/tests/test_s3_event_config_lambda.py
+++ b/tests/test_s3_event_config_lambda.py
@@ -48,13 +48,18 @@ def test_that_add_notification_adds_expected_settings_for_lambda(
     s3, mock_lambda_function
 ):
     s3.create_bucket(Bucket="some_bucket")
-    set_config = app.add_notification(
+    with mock.patch.object(
         s3,
-        "LambdaFunction",
-        mock_lambda_function["Configuration"]["FunctionArn"],
-        "some_bucket",
-        "test_folder",
-    )
+        "get_bucket_notification_configuration",
+        return_value={},
+    ):
+        app.add_notification(
+            s3,
+            "LambdaFunction",
+            mock_lambda_function["Configuration"]["FunctionArn"],
+            "some_bucket",
+            "test_folder",
+        )
     get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
     assert (
         get_config["LambdaFunctionConfigurations"][0]["LambdaFunctionArn"]
@@ -71,13 +76,18 @@ def test_that_add_notification_adds_expected_settings_for_lambda(
 @mock_s3
 def test_that_delete_notification_is_successful_for_lambda(s3, mock_lambda_function):
     s3.create_bucket(Bucket="some_bucket")
-    app.add_notification(
+    with mock.patch.object(
         s3,
-        "LambdaFunction",
-        mock_lambda_function["Configuration"]["FunctionArn"],
-        "some_bucket",
-        "test_folder",
-    )
+        "get_bucket_notification_configuration",
+        return_value={},
+    ):
+        app.add_notification(
+            s3,
+            "LambdaFunction",
+            mock_lambda_function["Configuration"]["FunctionArn"],
+            "some_bucket",
+            "test_folder",
+        )
     app.delete_notification(s3, "some_bucket")
     get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
     assert "LambdaFunctionConfigurations" not in get_config
@@ -86,13 +96,18 @@ def test_that_delete_notification_is_successful_for_lambda(s3, mock_lambda_funct
 @mock_s3
 def test_that_add_notification_adds_expected_settings_for_sqs(s3, mock_sqs_queue):
     s3.create_bucket(Bucket="some_bucket")
-    set_config = app.add_notification(
+    with mock.patch.object(
         s3,
-        "Queue",
-        mock_sqs_queue["Attributes"]["QueueArn"],
-        "some_bucket",
-        "test_folder",
-    )
+        "get_bucket_notification_configuration",
+        return_value={},
+    ):
+        app.add_notification(
+            s3,
+            "Queue",
+            mock_sqs_queue["Attributes"]["QueueArn"],
+            "some_bucket",
+            "test_folder",
+        )
     get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
     assert (
         get_config["QueueConfigurations"][0]["QueueArn"]
@@ -107,13 +122,18 @@ def test_that_add_notification_adds_expected_settings_for_sqs(s3, mock_sqs_queue
 @mock_s3
 def test_that_delete_notification_is_successful_for_sqs(s3, mock_sqs_queue):
     s3.create_bucket(Bucket="some_bucket")
-    app.add_notification(
+    with mock.patch.object(
         s3,
-        "Queue",
-        mock_sqs_queue["Attributes"]["QueueArn"],
-        "some_bucket",
-        "test_folder",
-    )
+        "get_bucket_notification_configuration",
+        return_value={},
+    ):
+        app.add_notification(
+            s3,
+            "Queue",
+            mock_sqs_queue["Attributes"]["QueueArn"],
+            "some_bucket",
+            "test_folder",
+        )
     app.delete_notification(s3, "some_bucket")
     get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
     assert "QueueConfigurations" not in get_config
@@ -147,7 +167,7 @@ def test_add_notification_does_nothing_if_notification_already_exists(
                 }
             ]
         },
-    ):
+    ), mock.patch.object(s3, "put_bucket_notification_configuration") as put_config:
         # WHEN I add the existing matching `LambdaFunction` configuration
         app.add_notification(
             s3,
@@ -161,7 +181,7 @@ def test_add_notification_does_nothing_if_notification_already_exists(
     get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
 
     # THEN I expect nothing to have been saved in our mocked environment
-    assert get_config.get("LambdaFunctionConfigurations", None) is None
+    assert not put_config.called
 
 
 @mock_s3
@@ -192,7 +212,7 @@ def test_add_notification_does_nothing_if_notification_already_exists_even_in_di
                 }
             ]
         },
-    ):
+    ), mock.patch.object(s3, "put_bucket_notification_configuration") as put_config:
         # WHEN I add the existing matching `LambdaFunction` configuration
         app.add_notification(
             s3,
@@ -206,7 +226,7 @@ def test_add_notification_does_nothing_if_notification_already_exists_even_in_di
     get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
 
     # THEN I expect nothing to have been saved in our mocked environment
-    assert get_config.get("LambdaFunctionConfigurations", None) is None
+    assert not put_config.called
 
 
 @mock_s3

--- a/tests/test_s3_event_config_lambda.py
+++ b/tests/test_s3_event_config_lambda.py
@@ -1,3 +1,4 @@
+from unittest import mock
 import zipfile
 import io
 import boto3
@@ -43,7 +44,9 @@ def mock_sqs_queue(mock_aws_credentials):
 
 
 @mock_s3
-def test_that_add_notification_adds_expected_settings_for_lambda(s3, mock_lambda_function):
+def test_that_add_notification_adds_expected_settings_for_lambda(
+    s3, mock_lambda_function
+):
     s3.create_bucket(Bucket="some_bucket")
     set_config = app.add_notification(
         s3,
@@ -86,18 +89,16 @@ def test_that_add_notification_adds_expected_settings_for_sqs(s3, mock_sqs_queue
     set_config = app.add_notification(
         s3,
         "Queue",
-        mock_sqs_queue['Attributes']['QueueArn'],
+        mock_sqs_queue["Attributes"]["QueueArn"],
         "some_bucket",
         "test_folder",
     )
     get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
     assert (
         get_config["QueueConfigurations"][0]["QueueArn"]
-        == mock_sqs_queue['Attributes']['QueueArn']
+        == mock_sqs_queue["Attributes"]["QueueArn"]
     )
-    assert get_config["QueueConfigurations"][0]["Events"] == [
-        "s3:ObjectCreated:*"
-    ]
+    assert get_config["QueueConfigurations"][0]["Events"] == ["s3:ObjectCreated:*"]
     assert get_config["QueueConfigurations"][0]["Filter"] == {
         "Key": {"FilterRules": [{"Name": "prefix", "Value": "test_folder/"}]}
     }
@@ -109,10 +110,210 @@ def test_that_delete_notification_is_successful_for_sqs(s3, mock_sqs_queue):
     app.add_notification(
         s3,
         "Queue",
-        mock_sqs_queue['Attributes']['QueueArn'],
+        mock_sqs_queue["Attributes"]["QueueArn"],
         "some_bucket",
         "test_folder",
     )
     app.delete_notification(s3, "some_bucket")
     get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
     assert "QueueConfigurations" not in get_config
+
+
+@mock_s3
+def test_add_notification_does_nothing_if_notification_already_exists(
+    s3, mock_lambda_function
+):
+    # GIVEN an S3 bucket
+    s3.create_bucket(Bucket="some_bucket")
+
+    # AND the bucket has an existing `LambdaFunctionConfigurations` that matches the one we will add
+    with mock.patch.object(
+        s3,
+        "get_bucket_notification_configuration",
+        return_value={
+            f"LambdaFunctionConfigurations": [
+                {
+                    f"LambdaFunctionArn": mock_lambda_function["Configuration"][
+                        "FunctionArn"
+                    ],
+                    "Events": ["s3:ObjectCreated:*"],
+                    "Filter": {
+                        "Key": {
+                            "FilterRules": [
+                                {"Name": "prefix", "Value": f"test_folder/"}
+                            ]
+                        }
+                    },
+                }
+            ]
+        },
+    ):
+        # WHEN I add the existing matching `LambdaFunction` configuration
+        app.add_notification(
+            s3,
+            "LambdaFunction",
+            mock_lambda_function["Configuration"]["FunctionArn"],
+            "some_bucket",
+            "test_folder",
+        )
+
+    # AND I get the notification configuration
+    get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
+
+    # THEN I expect nothing to have been saved in our mocked environment
+    assert get_config.get("LambdaFunctionConfigurations", None) is None
+
+
+@mock_s3
+def test_add_notification_does_nothing_if_notification_already_exists_even_in_different_dict_order(
+    s3, mock_lambda_function
+):
+    # GIVEN an S3 bucket
+    s3.create_bucket(Bucket="some_bucket")
+
+    # AND the bucket has an existing `LambdaFunctionConfigurations` that matches content of the one we will add - But differs in order
+    with mock.patch.object(
+        s3,
+        "get_bucket_notification_configuration",
+        return_value={
+            f"LambdaFunctionConfigurations": [
+                {
+                    "Filter": {
+                        "Key": {
+                            "FilterRules": [
+                                {"Name": "prefix", "Value": f"test_folder/"}
+                            ]
+                        }
+                    },
+                    "Events": ["s3:ObjectCreated:*"],
+                    f"LambdaFunctionArn": mock_lambda_function["Configuration"][
+                        "FunctionArn"
+                    ],
+                }
+            ]
+        },
+    ):
+        # WHEN I add the existing matching `LambdaFunction` configuration
+        app.add_notification(
+            s3,
+            "LambdaFunction",
+            mock_lambda_function["Configuration"]["FunctionArn"],
+            "some_bucket",
+            "test_folder",
+        )
+
+    # AND I get the notification configuration
+    get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
+
+    # THEN I expect nothing to have been saved in our mocked environment
+    assert get_config.get("LambdaFunctionConfigurations", None) is None
+
+
+@mock_s3
+def test_add_notification_adds_config_if_requested_notification_does_not_exist(
+    s3, mock_lambda_function, mock_sqs_queue
+):
+    # GIVEN an S3 bucket
+    s3.create_bucket(Bucket="some_bucket")
+
+    # AND the bucket has an existing `QueueConfigurations`
+    with mock.patch.object(
+        s3,
+        "get_bucket_notification_configuration",
+        return_value={
+            f"QueueConfigurations": [
+                {
+                    "Id": "123",
+                    "QueueArn": mock_sqs_queue["Attributes"]["QueueArn"],
+                    "Events": ["s3:ObjectCreated:*"],
+                    "Filter": {
+                        "Key": {
+                            "FilterRules": [
+                                {"Name": "prefix", "Value": f"test_folder/"}
+                            ]
+                        }
+                    },
+                }
+            ]
+        },
+    ):
+        # WHEN I add a new `LambdaFunction` configuration
+        app.add_notification(
+            s3,
+            "LambdaFunction",
+            mock_lambda_function["Configuration"]["FunctionArn"],
+            "some_bucket",
+            "test_folder",
+        )
+
+    # AND I get the notification configuration
+    get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
+
+    # THEN I expect to see a new `LambdaFunction` configuration
+    assert (
+        get_config["LambdaFunctionConfigurations"][0]["LambdaFunctionArn"]
+        == mock_lambda_function["Configuration"]["FunctionArn"]
+    )
+    assert get_config["LambdaFunctionConfigurations"][0]["Events"] == [
+        "s3:ObjectCreated:*"
+    ]
+    assert get_config["LambdaFunctionConfigurations"][0]["Filter"] == {
+        "Key": {"FilterRules": [{"Name": "prefix", "Value": "test_folder/"}]}
+    }
+
+    # AND I expect the `QueueConfigurations` to be unchanged
+    assert (
+        get_config["QueueConfigurations"][0]["QueueArn"]
+        == mock_sqs_queue["Attributes"]["QueueArn"]
+    )
+    assert get_config["QueueConfigurations"][0]["Events"] == ["s3:ObjectCreated:*"]
+    assert get_config["QueueConfigurations"][0]["Filter"] == {
+        "Key": {"FilterRules": [{"Name": "prefix", "Value": "test_folder/"}]}
+    }
+
+
+@mock_s3
+def test_add_notification_adds_config_if_existing_config_does_not_match(
+    s3, mock_lambda_function
+):
+    # GIVEN an S3 bucket
+    s3.create_bucket(Bucket="some_bucket")
+
+    # AND the bucket has an existing `LambdaFunctionConfigurations` that does not match the one we are adding
+    with mock.patch.object(
+        s3,
+        "get_bucket_notification_configuration",
+        return_value={
+            f"LambdaFunctionConfigurations": [
+                {
+                    f"SomeOtherArn": mock_lambda_function["Configuration"][
+                        "FunctionArn"
+                    ],
+                    "Events": ["s3:SomeOtherS3Event:*"],
+                }
+            ]
+        },
+    ):
+        # WHEN I add the `LambdaFunction` configuration
+        app.add_notification(
+            s3,
+            "LambdaFunction",
+            mock_lambda_function["Configuration"]["FunctionArn"],
+            "some_bucket",
+            "test_folder",
+        )
+
+    # AND I get the notification configuration
+    get_config = s3.get_bucket_notification_configuration(Bucket="some_bucket")
+
+    # THEN I expect to see the updated `LambdaFunction` configuration
+    assert (
+        get_config["LambdaFunctionConfigurations"][0]["LambdaFunctionArn"]
+        == mock_lambda_function["Configuration"]["FunctionArn"]
+    )
+    assert get_config["LambdaFunctionConfigurations"][0]["Events"] == [
+        "s3:ObjectCreated:*"
+    ]
+    assert get_config["LambdaFunctionConfigurations"][0]["Filter"] == {
+        "Key": {"FilterRules": [{"Name": "prefix", "Value": "test_folder/"}]}
+    }


### PR DESCRIPTION
**Problem:**

1. When running lamdba_function `s3_event_config` new notifications could not be added to an S3 bucket, instead the notification configuration was always overwritten.
2. When deleting a NotificationConfiguration for a specific type ALL notification types were deleted.

**Solution:**
A) Adding notifications:
            1) If a bucket has no `NotificationConfiguration` then create the config
            2) If a bucket has a `NotificationConfiguration` but no matching
                "{destination_arn}" for the "{destination_type}" then add the config
            3) If a bucket has a `NotificationConfiguration` and a matching
                                    "{destination_arn}" for the "{destination_type}":
                3a) If the config is the same then do nothing
                3b) If the config is different then overwrite the matching config
B) Deleting notifications - Only deleting the specific notificationConfiguration that matches the `"{destination_type}Configurations"` and destination arn

**Testing:**
I wrote unit tests for all paths