### PR TITLE
[ETL-562] Copy test data for integration testing

### DIFF
--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -278,6 +278,7 @@ jobs:
       - name: Copies over test files from ingestion bucket
         run: >
           aws s3 cp s3://recover-dev-ingestion/pilot-data/ s3://$DEV_INPUT_BUCKET/$NAMESPACE/
+          --recursive
           --exclude "owner.txt"
 
   sceptre-deploy-staging:

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -55,12 +55,6 @@ jobs:
           --namespace $NAMESPACE
           --cfn_bucket ${{ vars.CFN_BUCKET }}
 
-      - name: Copies over test files from ingestion bucket
-        run: >
-          aws s3 sync s3://recover-dev-ingestion/pilot-data/ s3://$DEV_INPUT_BUCKET/$NAMESPACE/
-          --exclude "owner.txt"
-
-
   nonglue-unit-tests:
     name: Runs unit tests that are not dependent on aws-glue package resources
     runs-on: ubuntu-latest
@@ -271,9 +265,6 @@ jobs:
       - name: Set namespace for non-default branch or for tag
         if: github.ref_name != 'main'
         run: echo "NAMESPACE=$GITHUB_REF_NAME" >> $GITHUB_ENV
-
-      - name: Setup sam
-        uses: aws-actions/setup-sam@v2
 
       - name: Copies over test files from ingestion bucket
         run: >

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -293,6 +293,43 @@ jobs:
           cd src/lambda_function/s3_to_glue/
           sam local invoke -e events/records.json --parameter-overrides "S3ToJsonWorkflowName=$NAMESPACE-S3ToJsonWorkflow"
 
+  # Reupload test files into the namespaced bucket after the branch was deployed.
+  # This is needed as the S3 event notifications aren't active until the branch is deployed.
+  reupload-files:
+    name: Re-upload files to S3 bucket in development
+    runs-on: ubuntu-latest
+    needs: integration-test-develop
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    environment: develop
+    steps:
+
+      - name: Setup code, pipenv, aws
+        uses: Sage-Bionetworks/action-pipenv-aws-setup@v3
+        with:
+          role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
+          role_session_name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          python_version: ${{ env.PYTHON_VERSION }}
+
+      - name: Setup sam
+        uses: aws-actions/setup-sam@v2
+
+      - name: Set namespace for non-default branch
+        if: github.ref_name != 'main'
+        run: echo "NAMESPACE=$GITHUB_REF_NAME" >> $GITHUB_ENV
+
+      - name: Delete test files from namespace bucket
+        run: >
+          aws s3 rm s3://$DEV_INPUT_BUCKET/$NAMESPACE/
+          --recursive
+          --exclude "owner.txt"
+
+      - name: Copies over test files from ingestion bucket
+        run: >
+          aws s3 sync s3://recover-dev-ingestion/pilot-data/ s3://$DEV_INPUT_BUCKET/$NAMESPACE/
+          --exclude "owner.txt"
 
   sceptre-deploy-staging:
     name: Deploys to staging of prod using sceptre

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -272,63 +272,12 @@ jobs:
         if: github.ref_name != 'main'
         run: echo "NAMESPACE=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
-      - name: generate test events
-        run: >
-          pipenv run python src/lambda_function/s3_to_glue/events/generate_test_event.py
-          --input-bucket $DEV_INPUT_BUCKET
-          --input-key-prefix $NAMESPACE
-          --output-directory ./src/lambda_function/s3_to_glue/events/
-
       - name: Setup sam
         uses: aws-actions/setup-sam@v2
-
-      - name: sam build lambda
-        run: >
-          sam build
-          -s src/lambda_function/s3_to_glue/
-          -t src/lambda_function/s3_to_glue/template.yaml
-
-      - name: Invoke Lambda
-        run: |
-          cd src/lambda_function/s3_to_glue/
-          sam local invoke -e events/records.json --parameter-overrides "S3ToJsonWorkflowName=$NAMESPACE-S3ToJsonWorkflow"
-
-  # Reupload test files into the namespaced bucket after the branch was deployed.
-  # This is needed as the S3 event notifications aren't active until the branch is deployed.
-  reupload-files:
-    name: Re-upload files to S3 bucket in development
-    runs-on: ubuntu-latest
-    needs: integration-test-develop
-    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-    permissions:
-      id-token: write
-      contents: read
-    environment: develop
-    steps:
-
-      - name: Setup code, pipenv, aws
-        uses: Sage-Bionetworks/action-pipenv-aws-setup@v3
-        with:
-          role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
-          role_session_name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
-          python_version: ${{ env.PYTHON_VERSION }}
-
-      - name: Setup sam
-        uses: aws-actions/setup-sam@v2
-
-      - name: Set namespace for non-default branch
-        if: github.ref_name != 'main'
-        run: echo "NAMESPACE=$GITHUB_REF_NAME" >> $GITHUB_ENV
-
-      - name: Delete test files from namespace bucket
-        run: >
-          aws s3 rm s3://$DEV_INPUT_BUCKET/$NAMESPACE/
-          --recursive
-          --exclude "owner.txt"
 
       - name: Copies over test files from ingestion bucket
         run: >
-          aws s3 sync s3://recover-dev-ingestion/pilot-data/ s3://$DEV_INPUT_BUCKET/$NAMESPACE/
+          aws s3 cp s3://recover-dev-ingestion/pilot-data/ s3://$DEV_INPUT_BUCKET/$NAMESPACE/
           --exclude "owner.txt"
 
   sceptre-deploy-staging:


### PR DESCRIPTION
Problem:
Previously we were manually creating test events to test the whole pipeline - instead we wanted the entire flow to handle this.

Solution:
Updating the integration test step to do an `aws cp` command to copy the test ingestion data

Testing:
See comment section of https://sagebionetworks.jira.com/browse/ETL-562 to see the whole flow having ran