### PR TITLE
Increase JSON to Parquet timeout

### DIFF
--- a/templates/glue-job-JSONToParquet.j2
+++ b/templates/glue-job-JSONToParquet.j2
@@ -49,7 +49,7 @@ Parameters:
   TimeoutInMinutes:
     Type: Number
     Description: The job timeout in minutes (integer).
-    Default: 720
+    Default: 1200
 
   TempS3Bucket:
     Type: String


### PR DESCRIPTION
This is approximately the largest timeout we could use while keeping the entire workflow time under ~22-24 hours.