### PR TITLE
[ETL-589] Fix parameter type in delete_objects call

### DIFF
--- a/src/glue/jobs/json_to_parquet.py
+++ b/src/glue/jobs/json_to_parquet.py
@@ -361,7 +361,7 @@ def archive_existing_datasets(
     if delete_upon_completion and archived_objects:
         deleted_response = s3_client.delete_objects(
                 Bucket=bucket,
-                Delete={"Objects": {"Key": obj["Key"] for obj in archived_objects}}
+                Delete={"Objects": [{"Key": obj["Key"]} for obj in archived_objects]}
         )
     return archived_objects
 

--- a/tests/test_json_to_parquet.py
+++ b/tests/test_json_to_parquet.py
@@ -926,7 +926,7 @@ class TestJsonS3ToParquet:
             )
             mock_client.delete_objects.assert_called_once_with(
                     Bucket=artifact_bucket,
-                    Delete={"Objects": {"Key": obj["Key"] for obj in archived_objects}}
+                    Delete={"Objects": [{"Key": obj["Key"]} for obj in archived_objects]}
             )
 
     def test_drop_deleted_healthkit_data(


### PR DESCRIPTION
TLDR: Parameter types are hard and I should check if things work in dev before pulling into prod