### PR TITLE
[ETL-590] Fitbit ecg

### DIFF
--- a/src/glue/jobs/json_to_parquet.py
+++ b/src/glue/jobs/json_to_parquet.py
@@ -39,6 +39,7 @@ INDEX_FIELD_MAP = {
     "fitbitdevices": ["ParticipantIdentifier", "Date"],
     "fitbitactivitylogs": ["LogId"],
     "fitbitdailydata": ["ParticipantIdentifier", "Date"],
+    "fitbitecg": ["FitbitEcgKey"],
     "fitbitintradaycombined": ["ParticipantIdentifier", "Type", "DateTime"],
     "fitbitrestingheartrates": ["ParticipantIdentifier", "Date"],
     "fitbitsleeplogs": ["LogId"],

--- a/src/glue/resources/table_columns.yaml
+++ b/src/glue/resources/table_columns.yaml
@@ -302,27 +302,33 @@ tables:
         Type: string
   FitbitEcg:
     columns:
-      - Name: startTime
+      - Name: FitbitEcgKey
         Type: string
-      - Name: averageHeartRate
+      - Name: ParticipantIdentifier
+        Type: string
+      - Name: ParticipantID
+        Type: string
+      - Name: StartTime
+        Type: string
+      - Name: AverageHeartRate
         Type: double
-      - Name: resultClassification
+      - Name: ResultClassification
         Type: string
-      - Name: waveformSamples
+      - Name: WaveformSamples
         Type: array<int>
-      - Name: samplingFrequencyHz
+      - Name: SamplingFrequencyHz
         Type: int
-      - Name: scalingFactor
+      - Name: ScalingFactor
         Type: int
-      - Name: numberOfWaveformSamples
+      - Name: NumberOfWaveformSamples
         Type: int
-      - Name: leadNumber
+      - Name: LeadNumber
         Type: int
-      - Name: featureVersion
+      - Name: FeatureVersion
         Type: string
-      - Name: deviceName
+      - Name: DeviceName
         Type: string
-      - Name: firmwareVersion
+      - Name: FirmwareVersion
         Type: string
     partition_keys:
       - Name: cohort

--- a/src/glue/resources/table_columns.yaml
+++ b/src/glue/resources/table_columns.yaml
@@ -300,6 +300,33 @@ tables:
     partition_keys:
       - Name: cohort
         Type: string
+  FitbitEcg:
+    columns:
+      - Name: startTime
+        Type: string
+      - Name: averageHeartRate
+        Type: double
+      - Name: resultClassification
+        Type: string
+      - Name: waveformSamples
+        Type: array<int>
+      - Name: samplingFrequencyHz
+        Type: int
+      - Name: scalingFactor
+        Type: int
+      - Name: numberOfWaveformSamples
+        Type: int
+      - Name: leadNumber
+        Type: int
+      - Name: featureVersion
+        Type: string
+      - Name: deviceName
+        Type: string
+      - Name: firmwareVersion
+        Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   FitbitDevices:
     columns:
       - Name: ParticipantIdentifier


### PR DESCRIPTION
**Problem:**
We are not ingesting fitbit ecg data in the recover pipeline

**Solution:**
Adding the new table schema and index field

**Testing:**
See the testing completed in the jira comments https://sagebionetworks.jira.com/browse/ETL-590 - I tested this against a sample data file provided to us and verified that we receive a parquet data file with the expected fields after running the pipeline.