### PR TITLE
[ETL-631] Update index fields with `ParticipantIdentifier` and propagate participant id fields

### DIFF
--- a/src/glue/resources/table_columns.yaml
+++ b/src/glue/resources/table_columns.yaml
@@ -330,6 +330,10 @@ tables:
         Type: string
       - Name: FirmwareVersion
         Type: string
+      - Name: export_start_date
+        Type: string
+      - Name: export_end_date
+        Type: string
     partition_keys:
       - Name: cohort
         Type: string


### PR DESCRIPTION
* Update index fields
* If parent parquet dataset has `ParticipantID` field, propagate that to the child
* Small change to the FitbitEcg schema to include the export start and end date fields