### PR TITLE
[ETL-653] Add corresponding deleted data type table for all HealthKit data types

### DIFF
--- a/src/glue/jobs/s3_to_json.py
+++ b/src/glue/jobs/s3_to_json.py
@@ -18,7 +18,12 @@ import boto3
 import ecs_logging
 from awsglue.utils import getResolvedOptions
 
-DATA_TYPES_WITH_SUBTYPE = ["HealthKitV2Samples", "HealthKitV2Statistics"]
+DATA_TYPES_WITH_SUBTYPE = [
+        "HealthKitV2Samples",
+        "HealthKitV2Statistics",
+        "HealthKitV2Samples_Deleted",
+        "HealthKitV2Statistics_Deleted"
+]
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -761,16 +766,7 @@ def get_metadata(basename: str) -> dict:
                 datetime.datetime.strptime(basename_components[-1], "%Y%m%d")
     if metadata["type"] in DATA_TYPES_WITH_SUBTYPE:
         metadata["subtype"] = basename_components[1]
-    if (
-        metadata["type"]
-        in [
-            "HealthKitV2Samples",
-            "HealthKitV2Heartbeat",
-            "HealthKitV2Electrocardiogram",
-            "HealthKitV2Workouts",
-        ]
-        and basename_components[-2] == "Deleted"
-    ):
+    if "HealthKitV2" in metadata["type"] and basename_components[-2] == "Deleted":
         metadata["type"] = "{}_Deleted".format(metadata["type"])
     return metadata
 

--- a/src/glue/resources/table_columns.yaml
+++ b/src/glue/resources/table_columns.yaml
@@ -67,6 +67,25 @@ tables:
     partition_keys:
       - Name: cohort
         Type: string
+  HealthKitV2Statistics_Deleted:
+    columns:
+      - Name: HealthKitStatisticKey
+        Type: string
+      - Name: ParticipantIdentifier
+        Type: string
+      - Name: ParticipantID
+        Type: string
+      - Name: Type
+        Type: string
+      - Name: DeletedDate
+        Type: string
+      - Name: export_start_date
+        Type: string
+      - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   HealthKitV2Samples:
     columns:
       - Name: HealthKitSampleKey
@@ -108,6 +127,8 @@ tables:
         Type: string
       - Name: ParticipantID
         Type: string
+      - Name: Type
+        Type: string
       - Name: DeletedDate
         Type: string
       - Name: export_start_date
@@ -142,6 +163,23 @@ tables:
       - Name: AppleStandHoursGoal
         Type: double
       - Name: InsertedDate
+        Type: string
+      - Name: export_start_date
+        Type: string
+      - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
+  HealthKitV2ActivitySummaries_Deleted:
+    columns:
+      - Name: HealthKitActivitySummaryKey
+        Type: string
+      - Name: ParticipantIdentifier
+        Type: string
+      - Name: ParticipantID
+        Type: string
+      - Name: DeletedDate
         Type: string
       - Name: export_start_date
         Type: string
@@ -189,6 +227,23 @@ tables:
     partition_keys:
       - Name: cohort
         Type: string
+  HealthKitV2Electrocardiogram_Deleted:
+    columns:
+      - Name: HealthKitECGSampleKey
+        Type: string
+      - Name: ParticipantIdentifier
+        Type: string
+      - Name: ParticipantID
+        Type: string
+      - Name: DeletedDate
+        Type: string
+      - Name: export_start_date
+        Type: string
+      - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   HealthKitV2Workouts:
     columns:
       - Name: HealthKitWorkoutKey
@@ -220,6 +275,23 @@ tables:
     partition_keys:
       - Name: cohort
         Type: string
+  HealthKitV2Workouts_Deleted:
+    columns:
+      - Name: HealthKitWorkoutKey
+        Type: string
+      - Name: ParticipantIdentifier
+        Type: string
+      - Name: ParticipantID
+        Type: string
+      - Name: DeletedDate
+        Type: string
+      - Name: export_start_date
+        Type: string
+      - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
   HealthKitV2Heartbeat:
     columns:
       - Name: HealthKitHeartbeatSampleKey
@@ -242,6 +314,23 @@ tables:
         Type: string
       - Name: Metadata
         Type: struct<HKAlgorithmVersion:string>
+      - Name: export_start_date
+        Type: string
+      - Name: export_end_date
+        Type: string
+    partition_keys:
+      - Name: cohort
+        Type: string
+  HealthKitV2Heartbeat_Deleted:
+    columns:
+      - Name: HealthKitHeartbeatSampleKey
+        Type: string
+      - Name: ParticipantIdentifier
+        Type: string
+      - Name: ParticipantID
+        Type: string
+      - Name: DeletedDate
+        Type: string
       - Name: export_start_date
         Type: string
       - Name: export_end_date

--- a/tests/test_json_to_parquet.py
+++ b/tests/test_json_to_parquet.py
@@ -127,6 +127,16 @@ def flat_data_type(glue_flat_table_name):
     return flat_data_type
 
 @pytest.fixture()
+def flat_inserted_date_data_type(glue_flat_inserted_date_table_name):
+    flat_inserted_date_data_type = glue_flat_inserted_date_table_name.split("_")[1]
+    return flat_inserted_date_data_type
+
+@pytest.fixture()
+def nested_data_type(glue_nested_table_name):
+    nested_data_type = glue_nested_table_name.split("_")[1]
+    return nested_data_type
+
+@pytest.fixture()
 def sample_table(
     spark_session, sample_table_data, glue_context, glue_flat_table_name
 ) -> DynamicFrame:
@@ -153,7 +163,6 @@ def sample_table_inserted_date(
         glue_context=glue_context,
     )
     return sample_table_inserted_date
-
 
 @pytest.fixture(scope="class")
 def glue_database_name(namespace):
@@ -183,6 +192,10 @@ def glue_flat_inserted_date_table_name():
 @pytest.fixture(scope="class")
 def glue_deleted_table_name(glue_flat_table_name):
     return f"{glue_flat_table_name}_deleted"
+
+@pytest.fixture(scope="class")
+def glue_deleted_nested_table_name(glue_nested_table_name) -> str:
+    return f"{glue_nested_table_name}_deleted"
 
 
 @pytest.fixture(scope="class")
@@ -381,6 +394,13 @@ def glue_deleted_table_location(glue_database_path, glue_deleted_table_name):
     )
     return glue_deleted_table_location
 
+@pytest.fixture(scope="class")
+def glue_deleted_nested_table_location(glue_database_path, glue_deleted_nested_table_name):
+    glue_deleted_nested_table_location = (
+        os.path.join(glue_database_path, glue_deleted_nested_table_name.replace("_", "=", 1))
+        + "/"
+    )
+    return glue_deleted_nested_table_location
 
 @pytest.fixture(scope="class")
 def glue_deleted_table(
@@ -415,6 +435,38 @@ def glue_deleted_table(
     )
     return glue_table
 
+@pytest.fixture(scope="class")
+def glue_deleted_nested_table(
+    glue_database_name, glue_deleted_nested_table_name, glue_deleted_nested_table_location
+):
+    glue_client = boto3.client("glue")
+    glue_table = glue_client.create_table(
+        DatabaseName=glue_database_name,
+        TableInput={
+            "Name": glue_deleted_nested_table_name,
+            "Description": "An empty table for pytest unit tests.",
+            "Retention": 0,
+            "TableType": "EXTERNAL_TABLE",
+            "StorageDescriptor": {
+                "Location": glue_deleted_nested_table_location,
+                "InputFormat": "org.apache.hadoop.mapred.TextInputFormat",
+                "OutputFormat": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+                "Compressed": False,
+                "StoredAsSubDirectories": False,
+                "Columns": [
+                    {"Name": "GlobalKey", "Type": "string"},
+                    {"Name": "export_end_date", "Type": "string"},
+                ],
+            },
+            "PartitionKeys": [{"Name": "cohort", "Type": "string"}],
+            "Parameters": {
+                "classification": "json",
+                "compressionType": "none",
+                "typeOfData": "file",
+            },
+        },
+    )
+    return glue_table
 
 def upload_test_data_to_s3(path, s3_bucket, table_location, data_cohort):
     s3_client = boto3.client("s3")
@@ -923,7 +975,7 @@ class TestJsonS3ToParquet:
                 Delete={"Objects": [{"Key": obj["Key"]} for obj in archived_objects]},
             )
 
-    def test_drop_deleted_healthkit_data(
+    def test_drop_deleted_healthkit_data_nonempty(
         self,
         glue_context,
         glue_flat_table_name,
@@ -948,6 +1000,62 @@ class TestJsonS3ToParquet:
             logger_context=logger_context,
         )
         assert table_after_drop.count() == 0
+
+    def test_drop_deleted_healthkit_data_empty(
+        self,
+        glue_context,
+        glue_nested_table_name,
+        nested_data_type,
+        glue_database_name,
+        glue_deleted_nested_table,
+        logger_context,
+    ):
+        # We do not upload any data for the deleted nested data type
+        # So we should receive our nested table back unaltered.
+        table = json_to_parquet.get_table(
+            table_name=glue_nested_table_name,
+            database_name=glue_database_name,
+            glue_context=glue_context,
+            record_counts=defaultdict(list),
+            logger_context=logger_context,
+        )
+        table_after_drop = json_to_parquet.drop_deleted_healthkit_data(
+            glue_context=glue_context,
+            table=table.toDF(),
+            table_name=table.name,
+            data_type=nested_data_type,
+            glue_database=glue_database_name,
+            record_counts=defaultdict(list),
+            logger_context=logger_context,
+        )
+        assert table_after_drop.count() == table.count()
+
+    def test_drop_deleted_healthkit_data_nonexistent_table(
+        self,
+        glue_context,
+        glue_flat_inserted_date_table_name,
+        flat_inserted_date_data_type,
+        glue_database_name,
+        logger_context,
+    ):
+        table = json_to_parquet.get_table(
+            table_name=glue_flat_inserted_date_table_name,
+            database_name=glue_database_name,
+            glue_context=glue_context,
+            record_counts=defaultdict(list),
+            logger_context=logger_context,
+        )
+        glue_client = boto3.client("glue")
+        with pytest.raises(glue_client.exceptions.EntityNotFoundException):
+            table_after_drop = json_to_parquet.drop_deleted_healthkit_data(
+                glue_context=glue_context,
+                table=table.toDF(),
+                table_name=table.name,
+                data_type=flat_inserted_date_data_type,
+                glue_database=glue_database_name,
+                record_counts=defaultdict(list),
+                logger_context=logger_context,
+            )
 
     def test_count_records_for_event_empty_table(self, sample_table, logger_context):
         spark_sample_table = sample_table.toDF()

--- a/tests/test_s3_to_json.py
+++ b/tests/test_s3_to_json.py
@@ -83,13 +83,17 @@ class TestS3ToJsonS3:
             "FitbitSleepLogs": "FitbitSleepLogs_20220111-20230103.json",
             "GoogleFitSamples": "GoogleFitSamples_20220111-20230103.json",
             "HealthKitV2ActivitySummaries": "HealthKitV2ActivitySummaries_20220111-20230103.json",
+            "HealthKitV2ActivitySummaries_Deleted": "HealthKitV2ActivitySummaries_Deleted_20220111-20230103.json",
             "HealthKitV2Electrocardiogram": "HealthKitV2Electrocardiogram_Samples_20220111-20230103.json",
+            "HealthKitV2Electrocardiogram_Deleted": "HealthKitV2Electrocardiogram_Samples_Deleted_20220111-20230103.json",
             "HealthKitV2Heartbeat": "HealthKitV2Heartbeat_Samples_20220401-20230112.json",
             "HealthKitV2Heartbeat_Deleted": "HealthKitV2Heartbeat_Samples_Deleted_20220401-20230112.json",
             "HealthKitV2Samples": "HealthKitV2Samples_AbdominalCramps_20220111-20230103.json",
             "HealthKitV2Samples_Deleted": "HealthKitV2Samples_AbdominalCramps_Deleted_20220111-20230103.json",
             "HealthKitV2Statistics": "HealthKitV2Statistics_HourlySteps_20201022-20211022.json",
+            "HealthKitV2Statistics_Deleted": "HealthKitV2Statistics_HourlySteps_Deleted_20201022-20211022.json",
             "HealthKitV2Workouts": "HealthKitV2Workouts_20220111-20230103.json",
+            "HealthKitV2Workouts_Deleted": "HealthKitV2Workouts_Deleted_20220111-20230103.json",
             "SymptomLog": "SymptomLog_20220401-20230112.json",
         }
         return json_file_basenames
@@ -577,8 +581,12 @@ class TestS3ToJsonS3:
         subtypes = [
             "subtype" in record.keys()
             for record in metadata
-            if record["type"]
-            not in ["HealthKitV2Samples", "HealthKitV2Samples_Deleted", "HealthKitV2Statistics"]
+            if record["type"] not in [
+                "HealthKitV2Samples",
+                "HealthKitV2Samples_Deleted",
+                "HealthKitV2Statistics",
+                "HealthKitV2Statistics_Deleted"
+            ]
         ]
         assert not any(subtypes),\
             "Some data types that are not HealthKitV2Samples or HealthKitV2Statistics have the metadata subtype key"


### PR DESCRIPTION
We didn't have `*_Deleted` tables for some HealthKit data types, which caused L255 of `src/glue/jobs/json_to_parquet.py` to raise a caught exception rather than removing deleted records for that data type. This only affected the `HealthKitV2Heartbeat` data type since we haven't received deleted records for any other HealthKit data type besides `HealthKitV2Samples`, which we already had a corresponding `*_Deleted` table for.

In addition to adding these new tables, I updated a few lines in `src/glue/jobs/s3_to_json.py`. In particular, the addition of the `HealthKitV2Samples_Deleted` and `HealthKitV2Statistics_Deleted` data types to the `DATA_TYPES_WITH_SUBTYPE` has the effect of adding the subtype included in the JSON file name into the JSON itself as a `Type` field. This field is not relevant when dropping deleted records from the data type, but it is file metadata which we were previously ignoring and not including in the resulting JSON datasets.