### PR TITLE
[ETL-648] Modify comparsion job to only consider records from recent exports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,11 @@ repos:
     rev: v1.4.1
     hooks:
       - id: remove-tabs
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)
+        entry: isort
+        language: python
+        types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,11 +17,11 @@ repos:
     rev: v1.4.1
     hooks:
       - id: remove-tabs
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
-    hooks:
-      - id: isort
-        name: isort (python)
-        entry: isort
-        language: python
-        types: [python]
+  #- repo: https://github.com/pre-commit/mirrors-isort
+  #  rev: v5.10.1
+  #  hooks:
+  #    - id: isort
+  #      name: isort (python)
+  #      entry: isort
+  #      language: python
+  #      types: [python]

--- a/Pipfile
+++ b/Pipfile
@@ -18,3 +18,6 @@ moto = "~=4.1"
 datacompy = "~=0.8"
 docker = "~=6.1"
 ecs_logging = "~=2.0"
+# flask libraries required for moto_server
+flask = "~=2.0"
+flask-cors = "~=3.0"

--- a/config/develop/namespaced/glue-workflow.yaml
+++ b/config/develop/namespaced/glue-workflow.yaml
@@ -16,6 +16,7 @@ parameters:
   S3ToJsonJobName: !stack_output_external "{{ stack_group_config.namespace }}-glue-job-S3ToJsonS3::JobName"
   CompareParquetStagingNamespace: {{ stack_group_config.namespace }}
   CompareParquetMainNamespace: "main"
+  CloudformationBucketName: {{ stack_group_config.template_bucket_name }}
 stack_tags:
   {{ stack_group_config.default_stack_tags }}
 sceptre_user_data:

--- a/config/develop/namespaced/glue-workflow.yaml
+++ b/config/develop/namespaced/glue-workflow.yaml
@@ -7,6 +7,7 @@ dependencies:
   - develop/namespaced/glue-job-JSONToParquet.yaml
   - develop/namespaced/glue-job-compare-parquet.yaml
   - develop/glue-job-role.yaml
+  - develop/s3-cloudformation-bucket.yaml
 parameters:
   Namespace: {{ stack_group_config.namespace }}
   JsonBucketName: {{ stack_group_config.intermediate_bucket_name }}
@@ -16,6 +17,7 @@ parameters:
   S3ToJsonJobName: !stack_output_external "{{ stack_group_config.namespace }}-glue-job-S3ToJsonS3::JobName"
   CompareParquetStagingNamespace: {{ stack_group_config.namespace }}
   CompareParquetMainNamespace: "main"
+  S3SourceBucketName: {{ stack_group_config.input_bucket_name }}
   CloudformationBucketName: {{ stack_group_config.template_bucket_name }}
 stack_tags:
   {{ stack_group_config.default_stack_tags }}

--- a/config/prod/namespaced/glue-workflow.yaml
+++ b/config/prod/namespaced/glue-workflow.yaml
@@ -7,6 +7,7 @@ dependencies:
   - prod/namespaced/glue-job-JSONToParquet.yaml
   - prod/namespaced/glue-job-compare-parquet.yaml
   - prod/glue-job-role.yaml
+  - prod/s3-cloudformation-bucket.yaml
 parameters:
   Namespace: {{ stack_group_config.namespace }}
   JsonBucketName: {{ stack_group_config.intermediate_bucket_name }}

--- a/config/prod/namespaced/glue-workflow.yaml
+++ b/config/prod/namespaced/glue-workflow.yaml
@@ -16,6 +16,8 @@ parameters:
   S3ToJsonJobName: !stack_output_external "{{ stack_group_config.namespace }}-glue-job-S3ToJsonS3::JobName"
   CompareParquetStagingNamespace: "staging"
   CompareParquetMainNamespace: "main"
+  S3SourceBucketName: {{ stack_group_config.input_bucket_name }}
+  CloudformationBucketName: {{ stack_group_config.template_bucket_name }}
 stack_tags:
   {{ stack_group_config.default_stack_tags }}
 sceptre_user_data:

--- a/src/glue/jobs/compare_parquet_datasets.py
+++ b/src/glue/jobs/compare_parquet_datasets.py
@@ -18,8 +18,8 @@ from pyarrow import fs
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-COHORTS = {"adults": "adults_v1", "pediatric": "pediatric_v1"}
-
+ADULTS = "adults_v1"
+PEDIATRIC = "pediatric_v1"
 INDEX_FIELD_MAP = {
     "dataset_enrolledparticipants": ["ParticipantIdentifier"],
     "dataset_fitbitprofiles": ["ParticipantIdentifier", "ModifiedDate"],
@@ -285,10 +285,10 @@ def get_cohort_from_s3_uri(s3_uri: str) -> Union[str, None]:
         Union[str, None]: the cohort if it exists
     """
     cohort = None
-    if COHORTS["adults"] in s3_uri:
-        cohort = COHORTS["adults"]
-    elif COHORTS["pediatric"] in s3_uri:
-        cohort = COHORTS["pediatric"]
+    if ADULTS  in s3_uri:
+        cohort = ADULTS
+    elif PEDIATRIC  in s3_uri:
+        cohort = PEDIATRIC
     else:
         pass
     return cohort

--- a/src/glue/jobs/compare_parquet_datasets.py
+++ b/src/glue/jobs/compare_parquet_datasets.py
@@ -418,7 +418,7 @@ def get_exports_filter_values(
 
 
 def convert_filter_values_to_expression(filter_values: Dict[str, str]) -> ds.Expression:
-    """ Converts the dict of the keys, values to filter on
+    """Converts the dict of the keys, values to filter on
         into filter conditions in the form of a pyarrow.dataset.Expression object
 
         The expression object takes the following structure for a single condition:
@@ -747,28 +747,24 @@ def upload_reports_to_s3(
     s3: boto3.client,
     reports: List[NamedTuple],
     data_type: str,
-    parquet_bucket_name: str,
+    parquet_bucket: str,
     staging_namespace: str,
 ) -> None:
-    """Uploads the various comparison reports to S3 bucket. We currently
-        support the following reports:
-            - main datacompy comparison report
-            - row differences in staging dataset
-            - row differences in main dataset
-            - duplicated data in staging dataset
-            - duplicated data in main dataset
+    """Uploads the various comparison reports to S3 bucket.
 
     Args:
-        s3 (boto3.client): _description_
-        compare_dict (Dict[str, datacompy.Compare]): _description_
-        data_type (str): _description_
-        parquet_bucket_name (str): _description_
-        staging_namespace (str): _description_
+        s3 (boto3.client): s3 client connection
+        reports (List[NamedTuple]): List of report which contain content(str) and
+        file_name(str). Content is the string body of the report and file_name is the
+        name of the file to be saved to S3.
+        data_type (str): data type to be compared for the given datasets
+        parquet_bucket (str): name of the bucket containing the parquet datasets
+        staging_namespace (str): name of namespace containing the "new" data
     """
     for report in reports:
         if report.content:
             s3.put_object(
-                Bucket=parquet_bucket_name,
+                Bucket=parquet_bucket,
                 Key=get_s3_file_key_for_comparison_results(
                     staging_namespace=staging_namespace,
                     data_type=data_type,

--- a/src/glue/jobs/compare_parquet_datasets.py
+++ b/src/glue/jobs/compare_parquet_datasets.py
@@ -733,6 +733,7 @@ def is_valid_dataset(dataset: pd.DataFrame, namespace: str) -> dict:
 def compare_datasets_by_data_type(
     s3,
     cfn_bucket: str,
+    input_bucket : str,
     parquet_bucket: str,
     staging_namespace: str,
     main_namespace: str,
@@ -742,6 +743,8 @@ def compare_datasets_by_data_type(
     """This runs the bulk of the comparison functions from beginning to end by data type
 
     Args:
+        cfn_bucket (str): name of the bucket containing the
+        input_bucket (str): name of the bucket containing the input data
         parquet_bucket (str): name of the bucket containing the parquet datasets
         staging_namespace (str): name of namespace containing the "new" data
         main_namespace (str): name of namespace containing the "established" data
@@ -766,6 +769,7 @@ def compare_datasets_by_data_type(
     filter_values = get_exports_filter_values(
         s3=s3,
         data_type=data_type,
+        input_bucket=input_bucket,
         cfn_bucket=cfn_bucket,
         staging_namespace=staging_namespace,
     )
@@ -790,7 +794,7 @@ def compare_datasets_by_data_type(
     # check that they have columns in common to compare
     elif not has_common_cols(staging_dataset, main_dataset):
         comparison_report = (
-            f"{staging_namespace} dataset and {main_namespace} have no columns in common."
+            f"{staging_namespace} dataset and {main_namespace} dataset have no columns in common."
             f" Comparison cannot continue."
         )
         compare = None
@@ -845,6 +849,8 @@ def main():
         logger.info(f"Running comparison report for {data_type}")
         compare_dict = compare_datasets_by_data_type(
             s3=s3,
+            cfn_bucket=args["cfn_bucket"],
+            input_bucket=args["input_bucket"],
             parquet_bucket=args["parquet_bucket"],
             staging_namespace=args["staging_namespace"],
             main_namespace=args["main_namespace"],

--- a/src/glue/jobs/compare_parquet_datasets.py
+++ b/src/glue/jobs/compare_parquet_datasets.py
@@ -87,31 +87,6 @@ INDEX_FIELD_MAP = {
     "dataset_garminusermetricssummary": ["ParticipantIdentifier", "CalenderDate"],
     "dataset_googlefitsamples": ["ParticipantIdentifier", "GoogleFitSampleKey"],
     "dataset_symptomlog": ["ParticipantIdentifier", "DataPointKey"],
-    # deleted data types
-    "dataset_healthkitv2samples_deleted": [
-        "ParticipantIdentifier",
-        "HealthKitSampleKey",
-    ],
-    "dataset_healthkitv2heartbeat_deleted": [
-        "ParticipantIdentifier",
-        "HealthKitHeartbeatSampleKey",
-    ],
-    "dataset_healthkitv2statistics_deleted": [
-        "ParticipantIdentifier",
-        "HealthKitStatisticKey",
-    ],
-    "dataset_healthkitv2electrocardiogram_deleted": [
-        "ParticipantIdentifier",
-        "HealthKitECGSampleKey",
-    ],
-    "dataset_healthkitv2workouts_deleted": [
-        "ParticipantIdentifier",
-        "HealthKitWorkoutKey",
-    ],
-    "dataset_healthkitv2activitysummaries_deleted": [
-        "ParticipantIdentifier",
-        "HealthKitActivitySummaryKey",
-    ],
 }
 
 
@@ -301,10 +276,10 @@ def get_data_type_from_filename(filename: str) -> Union[str, None]:
     {DataType}_[{DataSubType}_][Deleted_]{YYYYMMDD}[-{YYYYMMDD}].json
 
     Since we don't have support for DataSubType, we only support top
-    level datatypes or healthkitv2 datatypes with deleted samples
-    (e.g: healthkitv2samples_deleted) but because we only have the subtypes
+    level datatypes but because we only have the subtypes
     of the dataset in the exports, we can still use that to get the metadata
-    we need.
+    we need. We parse out deleted healthkit data types as we don't process them
+    into parquet.
 
     Args:
         filename (str): JSON filename

--- a/src/glue/jobs/compare_parquet_datasets.py
+++ b/src/glue/jobs/compare_parquet_datasets.py
@@ -691,7 +691,7 @@ def compare_datasets_by_data_type(
         s3_filesystem=s3_filesystem,
     )
     main_dataset = get_parquet_dataset(
-        filter=filter_values,
+        filter_values=filter_values,
         dataset_key=get_parquet_dataset_s3_path(
             parquet_bucket, main_namespace, data_type
         ),
@@ -818,7 +818,7 @@ def main():
         s3=s3,
         reports=reports,
         data_type=data_type,
-        parquet_bucket_name=args["parquet_bucket"],
+        parquet_bucket=args["parquet_bucket"],
         staging_namespace=args["staging_namespace"],
     )
     return

--- a/src/glue/jobs/compare_parquet_datasets.py
+++ b/src/glue/jobs/compare_parquet_datasets.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import datetime
 import json
 import logging
@@ -5,7 +6,7 @@ import os
 import sys
 import zipfile
 from io import BytesIO, StringIO
-from typing import List, Union
+from typing import Dict, List, NamedTuple, Union
 
 import boto3
 import datacompy
@@ -182,14 +183,26 @@ def get_additional_cols(
 
 
 def convert_dataframe_to_text(dataset: pd.DataFrame) -> str:
-    """Converts a pandas DataFrame into a string to save as csv in S3
+    """Converts a pandas DataFrame into a string to save as csv in S3.
+        If the dataframe is empty or has empty columns, it should just
+        return an empty string
 
-    NOTE: This is because s3.put_object only allows bytes or string
-    objects when saving them to S3"""
-    csv_buffer = StringIO()
-    dataset.to_csv(csv_buffer)
-    csv_content = csv_buffer.getvalue()
-    return csv_content
+        NOTE: This is because s3.put_object only allows bytes or string
+        objects when saving them to S3
+
+    Args:
+        dataset (pd.DataFrame): input dataset
+
+    Returns:
+        str: the resulting string conversion
+    """
+    if not dataset.empty:
+        csv_buffer = StringIO()
+        dataset.to_csv(csv_buffer)
+        csv_content = csv_buffer.getvalue()
+        return csv_content
+    else:
+        return ""
 
 
 def get_S3FileSystem_from_session(
@@ -364,13 +377,15 @@ def get_exports_filter_values(
     input_bucket: str,
     cfn_bucket: str,
     staging_namespace: str,
-) -> ds.Expression:
-    """Parses through the json exports and gets the filter values
+) -> Dict[str, str]:
+    """Parses through the json exports and gets the values
     for the cohort and export_end_date to filter on for our
-    main parquet dataset. These filter values (dict) are then
-    converted into filter conditions in the form of a
-    pyarrow.dataset.Expression object
-
+    main parquet dataset. The exports_filter will have the following
+    structure:
+        {
+            <cohort_name>: [<list of export_end_date values>],
+            ...
+        }
     Args:
         s3 (boto3.client): s3 client connection
         data_type (str): data type of the dataset
@@ -379,8 +394,8 @@ def get_exports_filter_values(
         staging_namespace (str): name of namespace containing the "new" data
 
     Returns:
-        ds.Expression: a pyarrow dataset expression object that contains
-        the filter conditions that can be applied to pyarrow datasets
+        Dict[str, str]: a dict containing the column(s) (key(s)) and values to
+        filter on
     """
     filelist = get_integration_test_exports_json(s3, cfn_bucket, staging_namespace)
     # create the dictionary of export end dates and cohort
@@ -399,10 +414,34 @@ def get_exports_filter_values(
             else:
                 continue
 
+    return export_end_date_vals
+
+
+def convert_filter_values_to_expression(filter_values: Dict[str, str]) -> ds.Expression:
+    """ Converts the dict of the keys, values to filter on
+        into filter conditions in the form of a pyarrow.dataset.Expression object
+
+        The expression object takes the following structure for a single condition:
+        (ds.field("cohort") == <cohort_name>) &
+        (ds.field("export_end_date").isin([<list of export_end_date values]))
+
+        For multiple conditions:
+        (ds.field("cohort") == <cohort_name>) & (ds.field("export_end_date").isin([<list of export_end_date values]))
+        | (ds.field("cohort") == <cohort_name>) & (ds.field("export_end_date").isin([<list of export_end_date values]))
+
+        When the filter_values is an empty {}, the filter is None
+
+    Args:
+        filter_values (Dict[str, str]): dict of the filter values
+
+    Returns:
+        ds.Expression: a pyarrow dataset expression object that contains
+        the filter conditions that can be applied to pyarrow datasets
+    """
     # create the filter using pyarrow and predicate pushdown
     exports_filter = None
-    if export_end_date_vals:
-        for cohort, values in export_end_date_vals.items():
+    if filter_values:
+        for cohort, values in filter_values.items():
             column_filter = (ds.field("cohort") == cohort) & (
                 ds.field("export_end_date").isin(values)
             )
@@ -417,21 +456,23 @@ def get_exports_filter_values(
 def get_parquet_dataset(
     dataset_key: str,
     s3_filesystem: fs.S3FileSystem,
-    filter: ds.Expression = None,
+    filter_values: Dict[str, str] = {},
 ) -> pd.DataFrame:
     """Returns a parquet dataset on S3 as a pandas dataframe.
-    The main dataset is optionally filtered using the exports_filter prior to being
+    The main dataset is optionally filtered using the filter_values
+    converted to a ds.Expression object prior to being
     read into memory.
 
     Args:
         dataset_key (str): The URI of the parquet dataset.
         s3_filesystem (S3FileSystem): A fs.S3FileSystem object
-        filter (ds.Expression, optional): A pyarrow dataset expression object
-            to filter the dataset on. Defaults to None.
+        filter_values (Dict[str, str]): A dictionary object containing
+            the columns (keys) and values to filter the dataset on. Defaults to {}.
 
     Returns:
         pd.DataFrame: the filtered table as a pandas dataframe
     """
+    ds_filter = convert_filter_values_to_expression(filter_values=filter_values)
     # Create the dataset object pointing to the S3 location
     table_source = dataset_key.split("s3://")[-1]
     dataset = ds.dataset(
@@ -442,36 +483,8 @@ def get_parquet_dataset(
     )
 
     # Apply any filter and read the dataset into a table
-    filtered_table = dataset.to_table(filter=filter)
+    filtered_table = dataset.to_table(filter=ds_filter)
     return filtered_table.to_pandas()
-
-
-def get_folders_in_s3_bucket(
-    s3: boto3.client, bucket_name: str, namespace: str
-) -> list:
-    """Gets the folders in the S3 bucket under the specific namespace
-
-    Args:
-        s3 (boto3.client): authenticated s3 client
-        bucket_name (str): name of the S3 bucket to look into
-        namespace (str): namespace of the path to look for folders in
-
-    Returns:
-        list: folder names inside S3 bucket
-    """
-
-    response = s3.list_objects_v2(
-        Bucket=bucket_name, Prefix=f"{namespace}/parquet/", Delimiter="/"
-    )
-    if "CommonPrefixes" in response.keys():
-        contents = response["CommonPrefixes"]
-        folders = [
-            os.path.normpath(content["Prefix"]).split(os.sep)[-1]
-            for content in contents
-        ]
-    else:
-        folders = []
-    return folders
 
 
 def get_duplicates(compare_obj: datacompy.Compare, namespace: str) -> pd.DataFrame:
@@ -540,48 +553,6 @@ def compare_column_names(
     return compare_msg
 
 
-def get_data_types_to_compare(
-    s3: boto3.client, bucket_name: str, staging_namespace: str, main_namespace: str
-) -> list:
-    """This gets the common data types to run the comparison of the parquet datasets from
-    the two namespaced paths on based on the folders in the s3 bucket"""
-    staging_datatype_folders = get_folders_in_s3_bucket(
-        s3, bucket_name, namespace=staging_namespace
-    )
-    main_datatype_folders = get_folders_in_s3_bucket(
-        s3, bucket_name, namespace=main_namespace
-    )
-    return list(set(staging_datatype_folders) & set(main_datatype_folders))
-
-
-def compare_dataset_data_types(
-    s3: boto3.client, bucket_name: str, staging_namespace: str, main_namespace: str
-) -> list:
-    """This looks at the current datatype folders in the S3 bucket between the
-    two namespaced paths and outputs a message if there are any differences
-    in the datatype folders"""
-    compare_msg = []
-    staging_datatype_folders = get_folders_in_s3_bucket(
-        s3, bucket_name, namespace=staging_namespace
-    )
-    main_datatype_folders = get_folders_in_s3_bucket(
-        s3, bucket_name, namespace=main_namespace
-    )
-    missing_datatypes = list(set(main_datatype_folders) - set(staging_datatype_folders))
-    add_datatypes = list(set(staging_datatype_folders) - set(main_datatype_folders))
-
-    if missing_datatypes:
-        compare_msg.append(
-            f"Staging dataset has the following missing data types: {str(missing_datatypes)}"
-        )
-
-    if add_datatypes:
-        compare_msg.append(
-            f"Staging dataset has the following additional data types: {str(add_datatypes)}"
-        )
-    return compare_msg
-
-
 def compare_datasets_and_output_report(
     data_type: str,
     staging_dataset: pd.DataFrame,
@@ -629,7 +600,7 @@ def add_additional_msg_to_comparison_report(
         comparison_report (str): report generated using datacompy
         add_msgs (list): list of additional messages to include at the bottom of the report
         msg_type (str): category of message, current available ones are
-            ["column_name_diff", "data_type_diff"]
+            ["column_name_diff"]
 
     Returns:
         str: updated comparison report with more specific messages
@@ -642,16 +613,8 @@ def add_additional_msg_to_comparison_report(
             f"Column Name Differences\n"
             f"-----------------------\n\n{joined_add_msgs}"
         )
-    elif msg_type == "data_type_diff":
-        updated_comparison_report = (
-            f"{comparison_report}"
-            f"Data Type Differences between the namespaces\n"
-            f"--------------------------------------------\n\n{joined_add_msgs}"
-        )
     else:
-        raise ValueError(
-            "msg_type param must be one of 'column_name_diff', 'data_type_diff'"
-        )
+        raise ValueError("msg_type param must be one of 'column_name_diff'")
     return updated_comparison_report
 
 
@@ -780,143 +743,88 @@ def compare_datasets_by_data_type(
     }
 
 
+def upload_reports_to_s3(
+    s3: boto3.client,
+    reports: List[NamedTuple],
+    data_type: str,
+    parquet_bucket_name: str,
+    staging_namespace: str,
+) -> None:
+    """Uploads the various comparison reports to S3 bucket. We currently
+        support the following reports:
+            - main datacompy comparison report
+            - row differences in staging dataset
+            - row differences in main dataset
+            - duplicated data in staging dataset
+            - duplicated data in main dataset
+
+    Args:
+        s3 (boto3.client): _description_
+        compare_dict (Dict[str, datacompy.Compare]): _description_
+        data_type (str): _description_
+        parquet_bucket_name (str): _description_
+        staging_namespace (str): _description_
+    """
+    for report in reports:
+        if report.content:
+            s3.put_object(
+                Bucket=parquet_bucket_name,
+                Key=get_s3_file_key_for_comparison_results(
+                    staging_namespace=staging_namespace,
+                    data_type=data_type,
+                    file_name=report.file_name,
+                ),
+                Body=report.content,
+            )
+
+
 def main():
     args = read_args()
     s3 = boto3.client("s3")
     aws_session = boto3.session.Session(region_name="us-east-1")
     fs = get_S3FileSystem_from_session(aws_session)
     data_type = args["data_type"]
-    data_types_to_compare = get_data_types_to_compare(
-        s3,
-        args["parquet_bucket"],
+    logger.info(f"Running comparison report for {data_type}")
+    compare_dict = compare_datasets_by_data_type(
+        s3=s3,
+        cfn_bucket=args["cfn_bucket"],
+        input_bucket=args["input_bucket"],
+        parquet_bucket=args["parquet_bucket"],
+        staging_namespace=args["staging_namespace"],
         main_namespace=args["main_namespace"],
+        s3_filesystem=fs,
+        data_type=data_type,
+    )
+    # List of reports with their corresponding parameters
+    ReportParams = namedtuple("ReportParams", ["file_name", "content"])
+    staging_row_diffs = convert_dataframe_to_text(
+        compare_row_diffs(compare_dict["compare_obj"], namespace="staging")
+    )
+    main_row_diffs = convert_dataframe_to_text(
+        compare_row_diffs(compare_dict["compare_obj"], namespace="main")
+    )
+    staging_dups = convert_dataframe_to_text(
+        get_duplicates(compare_dict["compare_obj"], namespace="staging")
+    )
+    main_dups = convert_dataframe_to_text(
+        get_duplicates(compare_dict["compare_obj"], namespace="main")
+    )
+    reports = [
+        ReportParams(
+            content=compare_dict["comparison_report"], file_name="parquet_compare.txt"
+        ),
+        ReportParams(content=staging_row_diffs, file_name="all_diff_staging_rows.csv"),
+        ReportParams(content=main_row_diffs, file_name="all_diff_main_rows.csv"),
+        ReportParams(content=staging_dups, file_name="all_dups_staging_rows.csv"),
+        ReportParams(content=main_dups, file_name="all_dups_main_rows.csv"),
+    ]
+    upload_reports_to_s3(
+        s3=s3,
+        reports=reports,
+        data_type=data_type,
+        parquet_bucket_name=args["parquet_bucket"],
         staging_namespace=args["staging_namespace"],
     )
-    data_types_diff = compare_dataset_data_types(
-        s3,
-        args["parquet_bucket"],
-        main_namespace=args["main_namespace"],
-        staging_namespace=args["staging_namespace"],
-    )
-    if data_types_to_compare:
-        logger.info(f"Running comparison report for {data_type}")
-        compare_dict = compare_datasets_by_data_type(
-            s3=s3,
-            cfn_bucket=args["cfn_bucket"],
-            input_bucket=args["input_bucket"],
-            parquet_bucket=args["parquet_bucket"],
-            staging_namespace=args["staging_namespace"],
-            main_namespace=args["main_namespace"],
-            s3_filesystem=fs,
-            data_type=data_type,
-        )
-        # update comparison report with the data_type differences message
-        comparison_report = add_additional_msg_to_comparison_report(
-            compare_dict["comparison_report"],
-            add_msgs=data_types_diff,
-            msg_type="data_type_diff",
-        )
-        # save comparison report to report folder in staging namespace
-        s3.put_object(
-            Bucket=args["parquet_bucket"],
-            Key=get_s3_file_key_for_comparison_results(
-                staging_namespace=args["staging_namespace"],
-                data_type=data_type,
-                file_name="parquet_compare.txt",
-            ),
-            Body=comparison_report,
-        )
-        logger.info("Comparison report saved!")
-        # additional report print outs
-        compare = compare_dict["compare_obj"]
-        # TODO: Find out if pandas.to_csv, or direct write to S3
-        # is more efficient. s3.put_object is very slow and memory heavy
-        # esp. if using StringIO conversion
-
-        # print out all mismatch columns
-        mismatch_cols_report = compare.all_mismatch()
-        if not mismatch_cols_report.empty:
-            s3.put_object(
-                Bucket=args["parquet_bucket"],
-                Key=get_s3_file_key_for_comparison_results(
-                    staging_namespace=args["staging_namespace"],
-                    data_type=data_type,
-                    file_name="all_mismatch_cols.csv",
-                ),
-                Body=convert_dataframe_to_text(mismatch_cols_report),
-            )
-            logger.info("Mismatch columns saved!")
-        # print out all staging rows that are different to main
-        staging_rows_report = compare_row_diffs(compare, namespace="staging")
-        if not staging_rows_report.empty:
-            s3.put_object(
-                Bucket=args["parquet_bucket"],
-                Key=get_s3_file_key_for_comparison_results(
-                    staging_namespace=args["staging_namespace"],
-                    data_type=data_type,
-                    file_name="all_diff_staging_rows.csv",
-                ),
-                Body=convert_dataframe_to_text(staging_rows_report),
-            )
-            logger.info("Different staging dataset rows saved!")
-        # print out all main rows that are different to staging
-        main_rows_report = compare_row_diffs(compare, namespace="main")
-        if not main_rows_report.empty:
-            s3.put_object(
-                Bucket=args["parquet_bucket"],
-                Key=get_s3_file_key_for_comparison_results(
-                    staging_namespace=args["staging_namespace"],
-                    data_type=data_type,
-                    file_name="all_diff_main_rows.csv",
-                ),
-                Body=convert_dataframe_to_text(main_rows_report),
-            )
-            logger.info("Different main dataset rows saved!")
-
-        # print out all staging duplicated rows
-        staging_dups_report = get_duplicates(compare, namespace="staging")
-        if not staging_dups_report.empty:
-            s3.put_object(
-                Bucket=args["parquet_bucket"],
-                Key=get_s3_file_key_for_comparison_results(
-                    staging_namespace=args["staging_namespace"],
-                    data_type=data_type,
-                    file_name="all_dup_staging_rows.csv",
-                ),
-                Body=convert_dataframe_to_text(staging_dups_report),
-            )
-            logger.info("Staging dataset duplicates saved!")
-        # print out all main duplicated rows
-        main_dups_report = get_duplicates(compare, namespace="main")
-        if not main_dups_report.empty:
-            s3.put_object(
-                Bucket=args["parquet_bucket"],
-                Key=get_s3_file_key_for_comparison_results(
-                    staging_namespace=args["staging_namespace"],
-                    data_type=data_type,
-                    file_name="all_dup_main_rows.csv",
-                ),
-                Body=convert_dataframe_to_text(main_dups_report),
-            )
-            logger.info("Main dataset duplicates saved!")
-    else:
-        # update comparison report with the data_type differences message
-        comparison_report = add_additional_msg_to_comparison_report(
-            comparison_report,
-            add_msgs=data_types_diff,
-            msg_type="data_type_diff",
-        )
-        print(comparison_report)
-        s3.put_object(
-            Bucket=args["parquet_bucket"],
-            Key=get_s3_file_key_for_comparison_results(
-                staging_namespace=args["staging_namespace"],
-                data_type=None,
-                file_name="data_types_compare.txt",
-            ),
-            Body=comparison_report,
-        )
-        logger.info("Comparison report saved!")
     return
 
 

--- a/src/glue/jobs/compare_parquet_datasets.py
+++ b/src/glue/jobs/compare_parquet_datasets.py
@@ -1,19 +1,19 @@
 import datetime
-from io import BytesIO, StringIO
 import json
 import logging
 import os
 import sys
-from typing import List, Union
 import zipfile
+from io import BytesIO, StringIO
+from typing import List, Union
 
-from awsglue.utils import getResolvedOptions
 import boto3
 import datacompy
 import pandas as pd
-from pyarrow import fs
 import pyarrow.dataset as ds
 import pyarrow.parquet as pq
+from awsglue.utils import getResolvedOptions
+from pyarrow import fs
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)

--- a/src/glue/jobs/compare_parquet_datasets.py
+++ b/src/glue/jobs/compare_parquet_datasets.py
@@ -1,11 +1,10 @@
-import argparse
 import datetime
 from io import BytesIO, StringIO
 import json
 import logging
 import os
 import sys
-from typing import Dict, List, Optional, Union
+from typing import List, Union
 import zipfile
 
 from awsglue.utils import getResolvedOptions
@@ -13,7 +12,6 @@ import boto3
 import datacompy
 import pandas as pd
 from pyarrow import fs
-import pyarrow.compute as pc
 import pyarrow.dataset as ds
 import pyarrow.parquet as pq
 

--- a/templates/glue-workflow.j2
+++ b/templates/glue-workflow.j2
@@ -285,7 +285,7 @@ Resources:
             "--input-bucket": !Ref S3SourceBucketName
             "--cfn-bucket": !Ref CloudformationBucketName
             "--parquet-bucket": !Ref ParquetBucketName
-            "--additional-python-modules": "datacompy~=0.8"
+            "--additional-python-modules": "datacompy~=0.8 flask~=2.0 flask-cors~=3.0"
         {% endfor %}
       Description: This trigger runs after completion of all JSON to Parquet jobs
       Type: CONDITIONAL

--- a/templates/glue-workflow.j2
+++ b/templates/glue-workflow.j2
@@ -79,7 +79,7 @@ Parameters:
 
   CloudformationBucketName:
     Type: String
-      Description: >-
+    Description: >-
         The name of the bucket where the cloudformation and artifacts are stored.
 
 Conditions:

--- a/templates/glue-workflow.j2
+++ b/templates/glue-workflow.j2
@@ -73,6 +73,15 @@ Parameters:
     Type: String
     Description: The name of the "main" namespace
 
+  S3SourceBucketName:
+    Type: String
+    Description: Name of the S3 bucket where source data are stored.
+
+  CloudformationBucketName:
+    Type: String
+      Description: >-
+        The name of the bucket where the cloudformation and artifacts are stored.
+
 Conditions:
   IsMainNamespace: !Equals [!Ref Namespace, "main"]
   IsDevelopmentNamespace: !Not [!Equals [!Ref Namespace, "main"]]
@@ -273,6 +282,8 @@ Resources:
             "--data-type": {{ "{}".format(dataset["table_name"]) }}
             "--main-namespace": !Ref CompareParquetMainNamespace
             "--staging-namespace": !Ref CompareParquetStagingNamespace
+            "--input-bucket": !Ref S3SourceBucketName
+            "--cfn-bucket": !Ref CloudformationBucketName
             "--parquet-bucket": !Ref ParquetBucketName
             "--additional-python-modules": "datacompy~=0.8"
         {% endfor %}

--- a/tests/Dockerfile.aws_glue_3
+++ b/tests/Dockerfile.aws_glue_3
@@ -1,4 +1,4 @@
 FROM amazon/aws-glue-libs:glue_libs_3.0.0_image_01
 
-RUN pip3 install moto~=4.1 datacompy~=0.8 pytest-datadir ecs_logging~=2.0
+RUN pip3 install moto~=4.1 datacompy~=0.8 pytest-datadir ecs_logging~=2.0 flask~=2.0 flask-cors~=3.0
 ENTRYPOINT ["bash", "-l"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,17 @@ def dataset_fixture(request):
     return request.getfixturevalue(request.param)
 
 
+@pytest.fixture
+def mock_s3_bucket():
+    """This allows us to persist the bucket and s3 client
+    """
+    with mock_s3():
+        s3 = boto3.client('s3', region_name='us-east-1')
+        bucket_name = 'test-bucket'
+        s3.create_bucket(Bucket=bucket_name)
+        yield s3, bucket_name
+
+
 @pytest.fixture()
 def valid_staging_dataset():
     yield pd.DataFrame(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,45 +6,79 @@ import pytest
 import pandas as pd
 from pyarrow import fs, parquet
 from moto import mock_s3
+from moto.server import ThreadedMotoServer
 
 
-@pytest.fixture(scope="function")
-def mock_aws_credentials():
-    """Mocked AWS Credentials for moto."""
-    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
-    os.environ["AWS_SECURITY_TOKEN"] = "testing"
-    os.environ["AWS_SESSION_TOKEN"] = "testing"
-    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+@pytest.fixture(scope="module")
+def mock_moto_server():
+    """A moto server to mock S3 interactions.
 
+    We cannot use the moto because pyarrow's S3 FileSystem
+    is not based on boto3 at all. Instead we use the moto_server
+    feature
+    (http://docs.getmoto.org/en/latest/docs/getting_started.html#stand-alone-server-mode),
+    which gives us an endpoint url, that can be used to construct a
+    pyarrow S3FileSystem that interacts with the moto server.
 
-@pytest.fixture(scope="function")
-def s3(mock_aws_credentials):
-    with mock_s3():
-        yield boto3.client("s3", region_name="us-east-1")
+    References:
+        https://github.com/apache/arrow/issues/31811
+    """
 
-
-@pytest.fixture(scope="function")
-def mock_aws_session(mock_aws_credentials):
-    with mock_s3():
-        yield boto3.session.Session(region_name="us-east-1")
+    server = ThreadedMotoServer(port=3000)
+    server.start()
+    yield "http://127.0.0.1:3000"
+    server.stop()
 
 
 @pytest.fixture()
+def mock_aws_credentials(monkeypatch):
+    """A mock AWS credentials environment."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+
+
+@pytest.fixture
+def s3():
+    with mock_s3():
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        yield s3_client
+
+
+@pytest.fixture
+def mock_aws_session(mock_aws_credentials):
+    with mock_s3():
+        aws_session = boto3.session.Session(region_name="us-east-1")
+        yield aws_session
+
+
+@pytest.fixture
 def parquet_bucket_name():
     yield "test-parquet-bucket"
 
 
-@pytest.fixture(scope="function")
-def mock_s3_filesystem(mock_aws_session):
-    with mock_s3():
-        session_credentials = mock_aws_session.get_credentials()
-        yield fs.S3FileSystem(
-            region="us-east-1",
-            access_key=session_credentials.access_key,
-            secret_key=session_credentials.secret_key,
-            session_token=session_credentials.token,
-        )
+@pytest.fixture
+def mock_s3_for_filesystem(mock_aws_session, mock_moto_server):
+    s3_client = mock_aws_session.client(
+        "s3", region_name="us-east-1", endpoint_url=mock_moto_server
+    )
+    yield s3_client
+
+
+@pytest.fixture
+def mock_s3_filesystem(mock_aws_credentials, mock_aws_session, mock_moto_server):
+    session_credentials = mock_aws_session.get_credentials()
+    filesystem = fs.S3FileSystem(
+        region="us-east-1",
+        access_key=session_credentials.access_key,
+        secret_key=session_credentials.secret_key,
+        session_token=session_credentials.token,
+        endpoint_override=mock_moto_server,
+    )
+    yield filesystem
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,7 @@ def dataset_fixture(request):
 def valid_staging_dataset():
     yield pd.DataFrame(
         {
+            "ParticipantIdentifier": ["X000000", "X000001", "X000002"],
             "LogId": [
                 "44984262767",
                 "46096730542",
@@ -90,6 +91,7 @@ def valid_staging_dataset():
 def valid_main_dataset():
     yield pd.DataFrame(
         {
+            "ParticipantIdentifier": ["X000000", "X000001", "X000002"],
             "LogId": [
                 "44984262767",
                 "46096730542",
@@ -130,6 +132,7 @@ def staging_dataset_with_missing_cols():
 def staging_dataset_with_add_cols():
     yield pd.DataFrame(
         {
+            "ParticipantIdentifier": ["X000000", "X000001", "X000002"],
             "LogId": [
                 "44984262767",
                 "46096730542",
@@ -156,38 +159,8 @@ def staging_dataset_with_add_cols():
 def staging_dataset_with_no_common_cols():
     yield pd.DataFrame(
         {
-            "ParticipantIdentifier": [
-                "MDH-9352-3209",
-                "MDH-9352-3209",
-                "MDH-9352-3209",
-            ],
             "Steps": ["866", "6074", "5744"],
             "OriginalDuration": ["768000", "2256000", "2208000"],
-        }
-    )
-
-
-@pytest.fixture()
-def staging_dataset_with_diff_data_type_cols():
-    yield pd.DataFrame(
-        {
-            "LogId": [
-                "44984262767",
-                "46096730542",
-                "51739302864",
-            ],
-            "StartDate": [
-                "2021-12-24T14:27:39+00:00",
-                "2022-02-18T08:26:54+00:00",
-                "2022-10-28T11:58:50+00:00",
-            ],
-            "EndDate": [
-                "2021-12-24T14:40:27+00:00",
-                "2022-02-18T09:04:30+00:00",
-                "2022-10-28T12:35:38+00:00",
-            ],
-            "ActiveDuration": [768000, 2256000, 2208000],
-            "Calories": [89.0, 473.0, 478.0],
         }
     )
 
@@ -196,6 +169,7 @@ def staging_dataset_with_diff_data_type_cols():
 def staging_dataset_with_diff_num_of_rows():
     yield pd.DataFrame(
         {
+            "ParticipantIdentifier": ["X000000"],
             "LogId": ["44984262767"],
             "StartDate": ["2021-12-24T14:27:39+00:00"],
             "EndDate": ["2021-12-24T14:40:27+00:00"],
@@ -232,20 +206,10 @@ def staging_dataset_with_dup_indexes():
 
 
 @pytest.fixture()
-def staging_dataset_with_all_col_val_diff():
+def staging_dataset_with_empty_columns():
     yield pd.DataFrame(
         {
-            "LogId": ["44984262767", "44984262767"],
-            "StartDate": ["2021-12-24T14:27:39+00:00", "2021-12-24T14:27:39+00:00"],
-            "EndDate": ["TESTING1", "TESTING2"],
-        }
-    )
-
-
-@pytest.fixture()
-def staging_dataset_with_empty_columns():
-    return pd.DataFrame(
-        {
+            "ParticipantIdentifier": [],
             "LogId": [],
             "StartDate": [],
             "EndDate": [],
@@ -255,7 +219,7 @@ def staging_dataset_with_empty_columns():
 
 @pytest.fixture()
 def staging_dataset_empty():
-    return pd.DataFrame()
+    yield pd.DataFrame()
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,7 @@
-import os
-from unittest import mock
-
 import boto3
 import pytest
 import pandas as pd
-from pyarrow import fs, parquet
+from pyarrow import parquet
 from moto import mock_s3
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 import boto3
-import pytest
 import pandas as pd
-from pyarrow import parquet
+import pytest
 from moto import mock_s3
+from pyarrow import parquet
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,28 +6,6 @@ import pytest
 import pandas as pd
 from pyarrow import fs, parquet
 from moto import mock_s3
-from moto.server import ThreadedMotoServer
-
-
-@pytest.fixture(scope="module")
-def mock_moto_server():
-    """A moto server to mock S3 interactions.
-
-    We cannot use the moto because pyarrow's S3 FileSystem
-    is not based on boto3 at all. Instead we use the moto_server
-    feature
-    (http://docs.getmoto.org/en/latest/docs/getting_started.html#stand-alone-server-mode),
-    which gives us an endpoint url, that can be used to construct a
-    pyarrow S3FileSystem that interacts with the moto server.
-
-    References:
-        https://github.com/apache/arrow/issues/31811
-    """
-
-    server = ThreadedMotoServer(port=3000)
-    server.start()
-    yield "http://127.0.0.1:3000"
-    server.stop()
 
 
 @pytest.fixture()
@@ -58,27 +36,6 @@ def mock_aws_session(mock_aws_credentials):
 @pytest.fixture
 def parquet_bucket_name():
     yield "test-parquet-bucket"
-
-
-@pytest.fixture
-def mock_s3_for_filesystem(mock_aws_session, mock_moto_server):
-    s3_client = mock_aws_session.client(
-        "s3", region_name="us-east-1", endpoint_url=mock_moto_server
-    )
-    yield s3_client
-
-
-@pytest.fixture
-def mock_s3_filesystem(mock_aws_credentials, mock_aws_session, mock_moto_server):
-    session_credentials = mock_aws_session.get_credentials()
-    filesystem = fs.S3FileSystem(
-        region="us-east-1",
-        access_key=session_credentials.access_key,
-        secret_key=session_credentials.secret_key,
-        session_token=session_credentials.token,
-        endpoint_override=mock_moto_server,
-    )
-    yield filesystem
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,14 +50,19 @@ def dataset_fixture(request):
 
 
 @pytest.fixture
-def mock_s3_bucket():
+def mock_s3_environment(mock_s3_bucket):
     """This allows us to persist the bucket and s3 client
     """
     with mock_s3():
         s3 = boto3.client('s3', region_name='us-east-1')
-        bucket_name = 'test-bucket'
-        s3.create_bucket(Bucket=bucket_name)
-        yield s3, bucket_name
+        s3.create_bucket(Bucket=mock_s3_bucket)
+        yield s3
+
+
+@pytest.fixture
+def mock_s3_bucket():
+    bucket_name = 'test-bucket'
+    yield bucket_name
 
 
 @pytest.fixture()

--- a/tests/test_compare_parquet_datasets.py
+++ b/tests/test_compare_parquet_datasets.py
@@ -1,17 +1,17 @@
-from io import BytesIO
 import json
-from unittest import mock
 import zipfile
+from io import BytesIO
+from unittest import mock
 
 import datacompy
-from moto import mock_s3
-from moto.server import ThreadedMotoServer
 import pandas as pd
-from pandas.testing import assert_frame_equal
 import pyarrow
-from pyarrow import fs, parquet
 import pyarrow.dataset as ds
 import pytest
+from moto import mock_s3
+from moto.server import ThreadedMotoServer
+from pandas.testing import assert_frame_equal
+from pyarrow import fs, parquet
 
 from src.glue.jobs import compare_parquet_datasets as compare_parquet
 

--- a/tests/test_compare_parquet_datasets.py
+++ b/tests/test_compare_parquet_datasets.py
@@ -234,11 +234,11 @@ def test_that_get_cohort_from_s3_uri_returns_expected(s3_uri, expected):
         ("EnrolledParticipants_20221027.json", "dataset_enrolledparticipants"),
         (
             "HealthKitV2Samples_WalkingStepLength_Deleted_20221024.json",
-            "dataset_healthkitv2samples_deleted",
+            None,
         ),
         (
             "HealthKitV2Workouts_Deleted_20221024.json",
-            "dataset_healthkitv2workouts_deleted",
+            None,
         ),
         (
             "NonexistentDataType_20221024.json",
@@ -391,8 +391,7 @@ def test_that_get_integration_test_exports_json_throws_json_decode_error(s3, jso
         (
             "dataset_healthkitv2samples_deleted",
             ["s3://bucket/pediatric_v1/file1.zip"],
-            (ds.field("cohort") == "pediatric_v1")
-            & (ds.field("export_end_date").isin(["2022-10-24T00:00:00"])),
+            None,
         ),
     ],
     ids=[

--- a/tests/test_compare_parquet_datasets.py
+++ b/tests/test_compare_parquet_datasets.py
@@ -1120,7 +1120,7 @@ def test_that_upload_reports_to_s3_has_expected_calls(s3):
         compare_parquet.upload_reports_to_s3(
             s3=s3,
             reports=reports,
-            parquet_bucket_name="my_bucket",
+            parquet_bucket="my_bucket",
             data_type="my_data_type",
             staging_namespace="my_namespace",
         )

--- a/tests/test_compare_parquet_datasets.py
+++ b/tests/test_compare_parquet_datasets.py
@@ -1029,7 +1029,7 @@ def test_that_compare_datasets_by_data_type_calls_compare_datasets_by_data_type_
                     s3_filesystem=None,
                 ),
                 mock.call(
-                    filter="some_filter",
+                    filter_values="some_filter",
                     dataset_key=f"s3://{parquet_bucket_name}/main/parquet/dataset_fitbitactivitylogs",
                     s3_filesystem=None,
                 ),

--- a/tests/test_compare_parquet_datasets.py
+++ b/tests/test_compare_parquet_datasets.py
@@ -1083,24 +1083,29 @@ def test_that_compare_datasets_by_data_type_does_not_call_compare_datasets_by_da
             " Comparison cannot continue."
         )
 
+def test_that_has_parquet_files_returns_false_with_incorrect_location(mock_s3_bucket):
+    s3, mock_bucket = mock_s3_bucket
+    s3.put_object(Bucket=mock_bucket, Key="incorrect_location/file1.parquet", Body="data")
+    assert compare_parquet.has_parquet_files(s3, mock_bucket, "test", "test_data") == False
+
 
 def test_that_has_parquet_files_returns_false_with_no_files(mock_s3_bucket):
     s3, mock_bucket = mock_s3_bucket
-    assert compare_parquet.has_parquet_files(s3, mock_bucket, "some/prefix/") == False
+    assert compare_parquet.has_parquet_files(s3, mock_bucket, "test", "test_data") == False
 
 
 def test_that_has_parquet_files_returns_false_with_no_parquet_files(mock_s3_bucket):
     s3, mock_bucket = mock_s3_bucket
-    s3.put_object(Bucket=mock_bucket, Key="some/prefix/file1.txt", Body="data")
-    s3.put_object(Bucket=mock_bucket, Key="some/prefix/file2.csv", Body="data")
-    assert compare_parquet.has_parquet_files(s3, mock_bucket, "some/prefix/") == False
+    s3.put_object(Bucket=mock_bucket, Key="test/parquet/test_data/file1.txt", Body="data")
+    s3.put_object(Bucket=mock_bucket, Key="test/parquet/test_data/file2.csv", Body="data")
+    assert compare_parquet.has_parquet_files(s3, mock_bucket, "test", "test_data") == False
 
 
 def test_that_has_parquet_files_returns_true_with_parquet_files(mock_s3_bucket):
     s3, mock_bucket = mock_s3_bucket
-    s3.put_object(Bucket=mock_bucket, Key="some/prefix/file1.parquet", Body="data")
-    s3.put_object(Bucket=mock_bucket, Key="some/prefix/file2.txt", Body="data")
-    assert compare_parquet.has_parquet_files(s3, mock_bucket, "some/prefix/") == True
+    s3.put_object(Bucket=mock_bucket, Key="test/parquet/test_data/file1.parquet", Body="data")
+    s3.put_object(Bucket=mock_bucket, Key="test/parquet/test_data/file2.txt", Body="data")
+    assert compare_parquet.has_parquet_files(s3, mock_bucket, "test", "test_data") == True
 
 
 def test_that_upload_reports_to_s3_has_expected_calls(s3):

--- a/tests/test_compare_parquet_datasets.py
+++ b/tests/test_compare_parquet_datasets.py
@@ -1119,7 +1119,7 @@ def test_that_compare_datasets_by_data_type_calls_compare_datasets_by_data_type_
             staging_namespace="staging",
         )
         patch_get_filtered_data.assert_called_once_with(
-            filter_values="some_filter",
+            exports_filter="some_filter",
             dataset_key=f"s3://{parquet_bucket_name}/main/parquet/dataset_fitbitactivitylogs",
             s3_filesystem=None,
         )


### PR DESCRIPTION
# Purpose
The purpose of this PR is to update the comparison job that compares parquet datasets between `staging` and `main` so that it incorporates the changes in #115 where we only submit the most recent ~2 weeks of exports for integration testing of running our staging pipeline all the way through. 

See [JIRA Ticket](https://sagebionetworks.jira.com/browse/ETL-648) for the full description and reasoning but essentially we pull the data type / cohort / export_end_date from the JSON array that contains the exports to be used in the integration test: `s3://{cloudformation_bucket_name}/{namespace}/integration_test_exports.json`, then use those values to filter the production parquet datasets (the ones in `main` namespace) before running the comparisons.

There's also an extra layer of difficulty because we don't currently support comparisons of subtype datasets just the top level datasets (and now deleted datasets)

# Changes
There's been a lot of maintenance changes other than the actual feature changes.

## Feature Changes

### Helper Functions
Addition of helper functions to help parse the exports for the filter values we need in order to filter our `main` dataset:
- [get_export_end_date](https://github.com/Sage-Bionetworks/recover/blob/etl-648/src/glue/jobs/compare_parquet_datasets.py#L230)
- [get_cohort_from_s3_uri](https://github.com/Sage-Bionetworks/recover/blob/etl-648/src/glue/jobs/compare_parquet_datasets.py#L263)
- [get_data_type_from_filename](https://github.com/Sage-Bionetworks/recover/blob/etl-648/src/glue/jobs/compare_parquet_datasets.py#L284)

A bunch of the code comes from [s3_to_json.py](https://github.com/Sage-Bionetworks/recover/blob/etl-648/src/glue/jobs/s3_to_json.py) but I only pulled out the snippets we need for the scope of this feature.

### Main feature functions:

1. [get_integration_test_exports_json](https://github.com/Sage-Bionetworks/recover/blob/etl-648/src/glue/jobs/compare_parquet_datasets.py#L349)
2. [get_json_files_in_zip_from_s3](https://github.com/Sage-Bionetworks/recover/blob/etl-648/src/glue/jobs/compare_parquet_datasets.py#L316)
3. [get_exports_filter_values](https://github.com/Sage-Bionetworks/recover/blob/etl-648/src/glue/jobs/compare_parquet_datasets.py#L373)
4. [convert_filter_values_to_expression](https://github.com/Sage-Bionetworks/recover/blob/etl-648/src/glue/jobs/compare_parquet_datasets.py#L419)
5. [get_parquet_dataset](https://github.com/Sage-Bionetworks/recover/blob/etl-648/src/glue/jobs/compare_parquet_datasets.py#L455)
This was a **pre-existing** function and has been redesigned. Note that we use `pyarrow`'s dataset feature for reading in the `main` dataset because we want to utilize the predicate pushdown feature of `pyarrow.datasets.dataset` which allows us to filter data early in the reading process, which can significantly improve performance by reducing I/O. This is helpful as our comparison jobs are limited in memory available given it's just a Python glue job.

## Maintenance Changes

###  From previous PRs
- Need to update the code to account for the update of the index fields with `ParticipantIdentifier` in #110 
- Need to update the code to account for the update of added deleted tables to our table schema in #116

We needed to update the `INDEX_FIELD_MAP` in this PR to reflect those changes and also update all our staging dataset vs main dataset test examples to incorporate those changes (e.g: `ParticipantIdentifier` is a required index column now for all data types thus it is used to join the staging dataset and main datasets so they are comparable)

### Mocking pyarrow's fileystem object using moto server
- Need to have a way to properly mock and test the [pyarrow S3 Filesystem object] (https://arrow.apache.org/docs/python/generated/pyarrow.fs.S3FileSystem.html) (this wasn't available before)

We also added two new libraries: `flask` and `flask-cors` to the extra libraries for the compare parquet glue job and python shell glue docker as they are required dependencies of using the [moto server](https://docs.getmoto.org/en/latest/docs/server_mode.html). This server is the only way to test using a filesystem object to read parquet from mocked s3 buckets (ref: https://github.com/apache/arrow/issues/31811). 

The function that use this moto server test are (and its respective unit tests): 
- [get_parquet_dataset](https://github.com/Sage-Bionetworks/recover/blob/etl-648/src/glue/jobs/compare_parquet_datasets.py#L455) and its [unit tests](https://github.com/Sage-Bionetworks/recover/blob/etl-648/tests/test_compare_parquet_datasets.py#L456-L668)

###  Redesigning how we check if a namespace has data of a specific data type
Thanks to [discussion here](https://github.com/Sage-Bionetworks/recover/pull/119#discussion_r1648030195), we decided to re-do the check for a data type in a specific namespace. We have removed all related functions as mentioned in the discussion and replaced it with the new function:
- [has_parquet_files](https://github.com/Sage-Bionetworks/recover/blob/etl-648/src/glue/jobs/compare_parquet_datasets.py#L745)
This is used in main to check that both the "staging" and "main" namespaces have parquet data before running the comparison reports

Prior to merging, we will need to clear the staging namespace in the `recover-intermediate-data` bucket

###  Refactoring `main` function
We had a lot of duplicated logic in the `main` function prior ([see comment here](https://github.com/Sage-Bionetworks/recover/pull/119#pullrequestreview-2131182682)) with the `s3.put_object` calls for every kind of report we wanted to upload to s3. That logic has been refactored in `main` alongside a new helper function to upload to s3:
- [upload_reports_to_s3](https://github.com/Sage-Bionetworks/recover/blob/etl-648/src/glue/jobs/compare_parquet_datasets.py#L774)

# Testing

- [x] Unit tests
- [x] Integration testing on `dev` pipeline
This runs successfully on the pipeline on the workflow: `wr_77376de723cc0781cefc0d2775a2e19cc269f54b020ae4e774637eb32b144050`. The comparison txt files are outputted to `s3://recover-dev-processed-data/etl-648/comparison_result/` and the export_end_dates for the main vs staging datasets match up. The comparison files show the expected differences between `etl-648` namespace and `main` namespace. See [JIRA Ticket comment](https://sagebionetworks.jira.com/browse/ETL-648?focusedCommentId=211429) for more details on this.