### PR TITLE
[ETL-671] Update to use older node version on aws actions

### DIFF
--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -14,7 +14,7 @@ env:
   PROD_INPUT_BUCKET: recover-input-data
   PROD_INTERMEDIATE_BUCKET: recover-intermediate-data
   INTEGRATION_TEST_NUM_EXPORTS: 28
-  #ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
 
@@ -100,20 +100,25 @@ jobs:
           --test-sts-permission read_write
           -v
 
-  setup:
-    name: Runs aws credentials configuration before tests
-    runs-on: ubuntu-latest
+
+  pytest-docker:
+    name: Build and push testing docker images to the pytest ECR repository.
     needs: pre-commit
-    environment: develop
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write
       contents: read
+    strategy:
+      matrix:
+        include:
+          - tag_name: aws_glue_3
+            dockerfile: tests/Dockerfile.aws_glue_3
+          - tag_name: aws_glue_4
+            dockerfile: tests/Dockerfile.aws_glue_4
+    environment: develop
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
       - name: Assume AWS role
-        id: assume-role
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
@@ -132,31 +137,7 @@ jobs:
           echo "username-key=$usernameKey" >> $GITHUB_OUTPUT
           passwordKey=docker_password_$(echo ${{ steps.login-ecr.outputs.registry }} | tr '.-' _)
           echo "password-key=$passwordKey" >> $GITHUB_OUTPUT
-    outputs:
-      ecr-registry: ${{ steps.login-ecr.outputs.registry }}
-      ecr-username: ${{ steps.login-ecr.outputs[steps.ecr.outputs.username-key] }}
-      ecr-password: ${{ steps.login-ecr.outputs[steps.ecr.outputs.password-key] }}
-
-
-  pytest-docker:
-    name: Build and push testing docker images to the pytest ECR repository.
-    needs: [setup]
-    runs-on: ubuntu-latest
-    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      matrix:
-        include:
-          - tag_name: aws_glue_3
-            dockerfile: tests/Dockerfile.aws_glue_3
-          - tag_name: aws_glue_4
-            dockerfile: tests/Dockerfile.aws_glue_4
-    environment: develop
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -166,14 +147,14 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: ${{ needs.setup.outputs.ecr-registry }}/pytest:${{ github.ref_name }}_${{ matrix.tag_name }}
+          tags: ${{ steps.login-ecr.outputs.registry }}/pytest:${{ github.ref_name }}_${{ matrix.tag_name }}
           file: ${{ matrix.dockerfile }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
     outputs:
-      ecr-registry: ${{ needs.setup.outputs.ecr-registry }}
-      ecr-username: ${{ needs.setup.outputs.ecr-username }}
-      ecr-password: ${{ needs.setup.outputs.ecr-password }}
+      ecr-registry: ${{ steps.login-ecr.outputs.registry }}
+      ecr-username: ${{ steps.login-ecr.outputs[steps.ecr.outputs.username-key] }}
+      ecr-password: ${{ steps.login-ecr.outputs[steps.ecr.outputs.password-key] }}
 
 
   glue-unit-tests:

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -14,6 +14,7 @@ env:
   PROD_INPUT_BUCKET: recover-input-data
   PROD_INTERMEDIATE_BUCKET: recover-intermediate-data
   INTEGRATION_TEST_NUM_EXPORTS: 28
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
 

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -134,8 +134,8 @@ jobs:
           echo "password-key=$passwordKey" >> $GITHUB_OUTPUT
     outputs:
       ecr-registry: ${{ steps.login-ecr.outputs.registry }}
-      ecr-username: ${{ steps.get-username.outputs.username-key }}
-      ecr-password: ${{ steps.get-password.outputs.password-key }}
+      ecr-username: ${{ steps.login-ecr.outputs[steps.ecr.outputs.username-key] }}
+      ecr-password: ${{ steps.login-ecr.outputs[steps.ecr.outputs.password-key] }}
 
 
   pytest-docker:

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -118,6 +118,8 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
           aws-region: "us-east-1"
+          # unmasking of the AWS account ID allows the acct id to pass through outputs
+          mask-aws-account-id: "no"
 
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -116,7 +116,7 @@ jobs:
         id: assume-role
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: ${{ secrets.AWS_CREDENTIALS_IAM_ROLE }}
+          role-to-assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
           aws-region: "us-east-1"
 
       - name: Login to Amazon ECR

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -100,10 +100,45 @@ jobs:
           --test-sts-permission read_write
           -v
 
+  setup:
+    name: Runs aws credentials configuration before tests
+    runs-on: ubuntu-latest
+    needs: pre-commit
+    environment: develop
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Assume AWS role
+        id: assume-role
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_CREDENTIALS_IAM_ROLE }}
+          aws-region: "us-east-1"
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Get ECR secret names
+        id: ecr
+        run: |
+          usernameKey=docker_username_$(echo ${{ steps.login-ecr.outputs.registry }} | tr '.-' _)
+          echo "username-key=$usernameKey" >> $GITHUB_OUTPUT
+          passwordKey=docker_password_$(echo ${{ steps.login-ecr.outputs.registry }} | tr '.-' _)
+          echo "password-key=$passwordKey" >> $GITHUB_OUTPUT
+    outputs:
+      ecr-registry: ${{ steps.login-ecr.outputs.registry }}
+      ecr-username: ${{ steps.get-username.outputs.username-key }}
+      ecr-password: ${{ steps.get-password.outputs.password-key }}
+
 
   pytest-docker:
     name: Build and push testing docker images to the pytest ECR repository.
-    needs: pre-commit
+    needs: [setup]
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
@@ -124,39 +159,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Assume AWS role
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
-          aws-region: "us-east-1"
-          # unmasking of the AWS account ID allows the acct id to pass through outputs
-          mask-aws-account-id: "no"
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Get ECR secret names
-        id: ecr
-        run: |
-          usernameKey=docker_username_$(echo ${{ steps.login-ecr.outputs.registry }} | tr '.-' _)
-          echo "username-key=$usernameKey" >> $GITHUB_OUTPUT
-          passwordKey=docker_password_$(echo ${{ steps.login-ecr.outputs.registry }} | tr '.-' _)
-          echo "password-key=$passwordKey" >> $GITHUB_OUTPUT
-
       - name: Build and push to ECR
         id: docker-build-push
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: ${{ steps.login-ecr.outputs.registry }}/pytest:${{ github.ref_name }}_${{ matrix.tag_name }}
+          tags: ${{ needs.setup.outputs.ecr-registry }}/pytest:${{ github.ref_name }}_${{ matrix.tag_name }}
           file: ${{ matrix.dockerfile }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
     outputs:
-      ecr-registry: ${{ steps.login-ecr.outputs.registry }}
-      ecr-username: ${{ steps.login-ecr.outputs[steps.ecr.outputs.username-key] }}
-      ecr-password: ${{ steps.login-ecr.outputs[steps.ecr.outputs.password-key] }}
+      ecr-registry: ${{ needs.setup.outputs.ecr-registry }}
+      ecr-username: ${{ needs.setup.outputs.ecr-username }}
+      ecr-password: ${{ needs.setup.outputs.ecr-password }}
 
 
   glue-unit-tests:

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -14,7 +14,7 @@ env:
   PROD_INPUT_BUCKET: recover-input-data
   PROD_INTERMEDIATE_BUCKET: recover-intermediate-data
   INTEGRATION_TEST_NUM_EXPORTS: 28
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+  #ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
 
@@ -118,6 +118,12 @@ jobs:
             dockerfile: tests/Dockerfile.aws_glue_4
     environment: develop
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -137,10 +143,6 @@ jobs:
           echo "username-key=$usernameKey" >> $GITHUB_OUTPUT
           passwordKey=docker_password_$(echo ${{ steps.login-ecr.outputs.registry }} | tr '.-' _)
           echo "password-key=$passwordKey" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
 
       - name: Build and push to ECR
         id: docker-build-push

--- a/tests/Dockerfile.aws_glue_3
+++ b/tests/Dockerfile.aws_glue_3
@@ -1,4 +1,26 @@
 FROM amazon/aws-glue-libs:glue_libs_3.0.0_image_01
 
+# Use the AWS Glue image as the base
+FROM amazon/aws-glue-libs:glue_libs_3.0.0_image_01
+
+# Update GLIBC
+RUN yum update -y && yum install -y gcc make wget \
+    && wget http://ftp.gnu.org/gnu/libc/glibc-2.28.tar.gz \
+    && tar -xzvf glibc-2.28.tar.gz \
+    && cd glibc-2.28 \
+    && mkdir build \
+    && cd build \
+    && ../configure --prefix=/opt/glibc-2.28 \
+    && make -j4 \
+    && make install \
+    && echo "/opt/glibc-2.28/lib" > /etc/ld.so.conf.d/glibc-2.28.conf \
+    && ldconfig
+
+# Set the new GLIBC in the environment
+ENV LD_LIBRARY_PATH=/opt/glibc-2.28/lib:$LD_LIBRARY_PATH
+
+# Verify GLIBC version
+RUN ldd --version
+
 RUN pip3 install moto~=4.1 datacompy~=0.8 pytest-datadir ecs_logging~=2.0 flask~=2.0 flask-cors~=3.0
 ENTRYPOINT ["bash", "-l"]

--- a/tests/Dockerfile.aws_glue_3
+++ b/tests/Dockerfile.aws_glue_3
@@ -1,29 +1,4 @@
 FROM amazon/aws-glue-libs:glue_libs_3.0.0_image_01
 
-# Update and install required tools
-RUN yum update -y && yum install -y gcc make wget
-
-# Download GLIBC source
-RUN wget http://ftp.gnu.org/gnu/libc/glibc-2.28.tar.gz
-
-# Extract GLIBC source
-RUN tar -xzvf glibc-2.28.tar.gz
-
-# Configure and install GLIBC
-WORKDIR glibc-2.28
-RUN mkdir build && cd build \
-    && ../configure --prefix=/opt/glibc-2.28 \
-    && make -j4 \
-    && make install
-
-# Set the new GLIBC in the environment
-RUN echo "/opt/glibc-2.28/lib" > /etc/ld.so.conf.d/glibc-2.28.conf && ldconfig
-
-# Set the new GLIBC in the environment
-ENV LD_LIBRARY_PATH=/opt/glibc-2.28/lib:$LD_LIBRARY_PATH
-
-# Verify GLIBC version
-RUN ldd --version
-
 RUN pip3 install moto~=4.1 datacompy~=0.8 pytest-datadir ecs_logging~=2.0 flask~=2.0 flask-cors~=3.0
 ENTRYPOINT ["bash", "-l"]

--- a/tests/Dockerfile.aws_glue_3
+++ b/tests/Dockerfile.aws_glue_3
@@ -1,20 +1,23 @@
 FROM amazon/aws-glue-libs:glue_libs_3.0.0_image_01
 
-# Use the AWS Glue image as the base
-FROM amazon/aws-glue-libs:glue_libs_3.0.0_image_01
+# Update and install required tools
+RUN yum update -y && yum install -y gcc make wget
 
-# Update GLIBC
-RUN yum update -y && yum install -y gcc make wget \
-    && wget http://ftp.gnu.org/gnu/libc/glibc-2.28.tar.gz \
-    && tar -xzvf glibc-2.28.tar.gz \
-    && cd glibc-2.28 \
-    && mkdir build \
-    && cd build \
+# Download GLIBC source
+RUN wget http://ftp.gnu.org/gnu/libc/glibc-2.28.tar.gz
+
+# Extract GLIBC source
+RUN tar -xzvf glibc-2.28.tar.gz
+
+# Configure and install GLIBC
+WORKDIR glibc-2.28
+RUN mkdir build && cd build \
     && ../configure --prefix=/opt/glibc-2.28 \
     && make -j4 \
-    && make install \
-    && echo "/opt/glibc-2.28/lib" > /etc/ld.so.conf.d/glibc-2.28.conf \
-    && ldconfig
+    && make install
+
+# Set the new GLIBC in the environment
+RUN echo "/opt/glibc-2.28/lib" > /etc/ld.so.conf.d/glibc-2.28.conf && ldconfig
 
 # Set the new GLIBC in the environment
 ENV LD_LIBRARY_PATH=/opt/glibc-2.28/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
**Purpose:** This is a draft PR because this is just a temp. solution. There is a known discrepancy between the `glibc` version used by the aws glue docker images (2.26) and `glibc` version used by all of the AWS actions  versionswhich is expecting >= 2.27. Until the aws glue docker images are updated to use Node js version 20 (which uses glibc >= 2.27), this is the discovered workaround. [See blog post for more info](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/). This discussion gives a good view into the issue itself: https://github.com/actions/checkout/issues/1809#issue-2389388431

This solution is still temp. because ideally aws updates their aws glue docker images to use node js 20.

See [JIRA ticket](https://sagebionetworks.jira.com/browse/ETL-671) comments for more detailed updates on what was tried

**Testing:** Our GH actions for aws credentials now works without error