### PR TITLE
[ETL-670] Adjust cleanup job to run on `main` directory of dev env

### DIFF
--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -269,7 +269,6 @@ jobs:
       contents: read
     steps:
       - name: Setup code, pipenv, aws
-        if: github.ref_name != 'main'
         uses: Sage-Bionetworks/action-pipenv-aws-setup@v3
         with:
           role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
@@ -281,14 +280,12 @@ jobs:
         run: echo "NAMESPACE=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
       - name: Clean input data bucket
-        if: github.ref_name != 'main'
         run: >
           pipenv run python src/scripts/manage_artifacts/clean_for_integration_test.py
           --bucket $DEV_INPUT_BUCKET
           --bucket_prefix "${{ env.NAMESPACE }}/"
 
       - name: Clean intermediate data bucket
-        if: github.ref_name != 'main'
         run: >
           pipenv run python src/scripts/manage_artifacts/clean_for_integration_test.py
           --bucket $DEV_INTERMEDIATE_BUCKET

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -262,7 +262,6 @@ jobs:
     name: Cleanup non-main branch data before integration tests
     runs-on: ubuntu-latest
     needs: sceptre-deploy-develop
-    if: github.ref_name != 'main'
     environment: develop
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
@@ -270,6 +269,7 @@ jobs:
       contents: read
     steps:
       - name: Setup code, pipenv, aws
+        if: github.ref_name != 'main'
         uses: Sage-Bionetworks/action-pipenv-aws-setup@v3
         with:
           role_to_assume: ${{ vars.AWS_CREDENTIALS_IAM_ROLE }}
@@ -277,15 +277,18 @@ jobs:
           python_version: ${{ env.PYTHON_VERSION }}
 
       - name: Set namespace for non-default branch
+        if: github.ref_name != 'main'
         run: echo "NAMESPACE=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
       - name: Clean input data bucket
+        if: github.ref_name != 'main'
         run: >
           pipenv run python src/scripts/manage_artifacts/clean_for_integration_test.py
           --bucket $DEV_INPUT_BUCKET
           --bucket_prefix "${{ env.NAMESPACE }}/"
 
       - name: Clean intermediate data bucket
+        if: github.ref_name != 'main'
         run: >
           pipenv run python src/scripts/manage_artifacts/clean_for_integration_test.py
           --bucket $DEV_INTERMEDIATE_BUCKET

--- a/src/scripts/manage_artifacts/clean_for_integration_test.py
+++ b/src/scripts/manage_artifacts/clean_for_integration_test.py
@@ -42,8 +42,6 @@ def delete_objects(bucket_prefix: str, bucket: str) -> None:
             # Skip the owner.txt file so it does not need to be re-created
             if object_key.endswith("owner.txt"):
                 continue
-            elif "main" in object_key:
-                raise ValueError("Cannot delete objects in the main directory")
 
             s3_client.delete_object(Bucket=bucket, Key=object_key)
 
@@ -55,9 +53,6 @@ def main() -> None:
 
     if not args.bucket_prefix or args.bucket_prefix[-1] != "/":
         raise ValueError("Bucket prefix must be provided and end with a '/'")
-
-    if "main" in args.bucket_prefix:
-        raise ValueError("Cannot delete objects in the main directory")
 
     try:
         delete_objects(bucket_prefix=args.bucket_prefix, bucket=args.bucket)

--- a/src/scripts/manage_artifacts/clean_for_integration_test.py
+++ b/src/scripts/manage_artifacts/clean_for_integration_test.py
@@ -54,6 +54,11 @@ def main() -> None:
     if not args.bucket_prefix or args.bucket_prefix[-1] != "/":
         raise ValueError("Bucket prefix must be provided and end with a '/'")
 
+    if "main" in args.bucket_prefix and "recover-dev" not in args.bucket:
+        raise ValueError(
+            "Cannot delete objects in the main directory of a non-dev bucket"
+        )
+
     try:
         delete_objects(bucket_prefix=args.bucket_prefix, bucket=args.bucket)
     except Exception as ex:


### PR DESCRIPTION
Problem:

1. We do want to run the cleanup on the `main` directory of the dev branch

Solution:

1. Updating the workflow so the job is triggered and we are able to clean the `main` directory

Testing:

1. Will be looking at the workflow run