### PR TITLE
[ETL-659] Enable any branch to be deployed to any environment

### DIFF
--- a/.github/workflows/upload-and-deploy-to-prod-main.yaml
+++ b/.github/workflows/upload-and-deploy-to-prod-main.yaml
@@ -136,6 +136,7 @@ jobs:
       - name: Deploy Snowflake objects
         run: |
           snow sql \
+            -D "git_branch=main" \
             -D "environment=main" \
             -f snowflake/objects/deploy.sql
 

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -75,6 +75,7 @@ jobs:
       - name: Deploy Snowflake objects
         run: |
           snow sql \
+            -D "git_branch=$GITHUB_REF_NAME" \
             -D "environment=$SNOWFLAKE_ENVIRONMENT" \
             -f snowflake/objects/deploy.sql
 


### PR DESCRIPTION
When merging a PR into main, we deploy changes to a `staging` Snowflake environment. Because we can only do variable substitution in a stage path using CLI variables when invoking our entrypoint `snowflake/objects/deploy.sql` from the command line, I've split the `environment` variable into an `environment` and `git_branch` variable. Both must be specified.