### PR TITLE
[ETL-683] Increase memory of raw lambda

### DIFF
--- a/src/lambda_function/raw/template.yaml
+++ b/src/lambda_function/raw/template.yaml
@@ -52,7 +52,7 @@ Resources:
       Handler: app.lambda_handler
       Runtime: !Sub "python${LambdaPythonVersion}"
       Role: !Ref RoleArn
-      MemorySize: 1024
+      MemorySize: 1769
       EphemeralStorage:
         Size: 2048
       Timeout: 900


### PR DESCRIPTION
Changes:
* Increased memory from 1024 to 1769 (1 vCPU).
* Put `compressed_data` in a context manager so that we don't have to manually close
* Removed return statement at end of `main` in case we ever want to use a batch size larger than 1.

Details about benchmarking exploration are [here](https://sagebionetworks.jira.com/browse/ETL-683?focusedCommentId=219741).