### PR TITLE
Enable raw sync events rule

### DIFF
--- a/config/develop/namespaced/events-rule-raw-sync.yaml
+++ b/config/develop/namespaced/events-rule-raw-sync.yaml
@@ -5,7 +5,7 @@ dependencies:
   - develop/namespaced/lambda-raw-sync.yaml
 parameters:
   RuleName: "{{ stack_group_config.namespace }}-lambda-raw-sync-trigger"
-  RuleState: DISABLED
+  RuleState: ENABLED
   LambdaArn: !stack_output_external "{{ stack_group_config.namespace }}-lambda-raw-sync::RawSyncFunctionArn"
   CronSchedule: cron(0 0 * * ? *)
 stack_tags:


### PR DESCRIPTION
#141 Did not have the events rule which triggers the raw sync lambda enabled before merging. This PR rectifies that.