### PR TITLE
[DPE-1584] Add external IAM user with limited read access

### DIFF
--- a/config/prod/s3-input-bucket.yaml
+++ b/config/prod/s3-input-bucket.yaml
@@ -6,5 +6,8 @@ stack_name: recover-input-bucket
 parameters:
   BucketName: {{ stack_group_config.input_bucket_name }}
   ConnectToSynapse: "true"
+  EnableExternalTransfer: "true"
+  ExternalTransferRoleArn: "arn:aws:iam::714862078411:user/rixing.xu@sagebase.org"
+  ExternalTransferPrefix: "main/"
 stack_tags:
   {{ stack_group_config.default_stack_tags }}

--- a/config/prod/s3-processed-data-bucket.yaml
+++ b/config/prod/s3-processed-data-bucket.yaml
@@ -5,5 +5,8 @@ stack_name: recover-processed-data-bucket
 parameters:
   BucketName: {{ stack_group_config.processed_data_bucket_name }}
   ConnectToSynapse: "true"
+  EnableExternalTransfer: "true"
+  ExternalTransferRoleArn: "arn:aws:iam::714862078411:user/rixing.xu@sagebase.org"
+  ExternalTransferPrefix: "main/parquet/archive/"
 stack_tags:
   {{ stack_group_config.default_stack_tags }}

--- a/templates/s3-bucket.yaml
+++ b/templates/s3-bucket.yaml
@@ -19,15 +19,36 @@ Parameters:
       - "false"
     Default: "false"
 
+  EnableExternalTransfer:
+    Type: String
+    Description: Whether to grant an external IAM role read permissions for cross-account aws s3 sync (source bucket).
+    AllowedValues:
+      - "true"
+      - "false"
+    Default: "false"
+
+  ExternalTransferRoleArn:
+    Type: String
+    Description: IAM Role ARN (preferred) or IAM User ARN of the external principal that will read from this bucket.
+    Default: ""
+
+  ExternalTransferPrefix:
+    Type: String
+    Description: Optional prefix (folder) to restrict external reads (e.g., "exports/"). Leave blank to allow entire bucket.
+    Default: ""
+
 Conditions:
   HasBucketName: !Not [!Equals [!Ref BucketName, ""]]
   ConnectToSynapse:
     !Equals [!Ref ConnectToSynapse, "true"]
+  EnableExternalTransfer:
+    !Equals [!Ref EnableExternalTransfer, "true"]
 
 Resources:
   Bucket:
     Type: AWS::S3::Bucket
-    DeletionPolicy: Delete
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       BucketName: !If [HasBucketName, !Ref BucketName, !Ref 'AWS::NoValue']
       AccessControl: Private
@@ -64,6 +85,36 @@ Resources:
             Resource:
               - !Sub 'arn:aws:s3:::${Bucket}'
               - !Sub 'arn:aws:s3:::${Bucket}/*'
+          # Deny HTTP requests
+          - Sid: DenyInsecureTransport
+            Effect: Deny
+            Principal: "*"
+            Action: "s3:*"
+            Resource:
+              - !Sub 'arn:aws:s3:::${Bucket}'
+              - !Sub 'arn:aws:s3:::${Bucket}/*'
+            Condition:
+              Bool:
+                aws:SecureTransport: "false"
+          # Optional external transfer read access (for aws s3 sync as SOURCE)
+          - !If
+            - EnableExternalTransfer
+            - Sid: ExternalTransferRead
+              Effect: Allow
+              Principal:
+                AWS: !Ref ExternalTransferRoleArn
+              Action:
+                - "s3:ListBucket"
+                - "s3:GetObject"
+              Resource:
+                - !Sub 'arn:aws:s3:::${Bucket}'
+                - !Sub "arn:aws:s3:::${Bucket}/${ExternalTransferPrefix}*"
+              Condition:
+                StringLike:
+                  s3:prefix:
+                    - !Sub "${ExternalTransferPrefix}*"
+                    - !Ref ExternalTransferPrefix
+            - !Ref AWS::NoValue
           - !If
             - ConnectToSynapse
             - Sid: SynapseBucketAccess


### PR DESCRIPTION
**Problem:**
This PR is mainly for tracking purposes of what we may have done to the bucket policy (could deploy / manually add first). We need to give external IAM role limited read access to certain buckets.

**Solution:**
Add external IAM role with `ListBucket` and `GetObject` permissions to be able to do a data transfer on the `recover-input-data` and `recover-processed-data` buckets to external s3 bucket.

Extras: Added the deny http requests part to the bucket policy as that was previously added manually

**Testing:**
WIP
